### PR TITLE
Basic CSR generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 der = { version = "0.7.8", features = ["pem"] }
 spki = "0.7.3"
 thiserror = "1.0.57"
-x509-cert = { version = "0.2.5", default-features = false, features = ["pem"] }
-openssl = "0.10.64"
+x509-cert = { version = "0.2.5", default-features = false }
 
 [dev-dependencies]
 ed25519-dalek = { version = "2.1.1", features = ["rand_core", "signature"] }

--- a/examples/ed25519_basic.rs
+++ b/examples/ed25519_basic.rs
@@ -86,6 +86,20 @@ impl Signature for Ed25519Signature {
             parameters: None,
         }
     }
+
+    fn from_bitstring(signature: &[u8]) -> Self {
+        let mut signature_vec = signature.to_vec();
+        signature_vec.resize(64, 0);
+        let signature_array: [u8; 64] = {
+            let mut array = [0; 64];
+            array.copy_from_slice(&signature_vec[..]);
+            array
+        };
+        Self {
+            signature: Ed25519DalekSignature::from_bytes(&signature_array),
+            algorithm: Self::algorithm_identifier(),
+        }
+    }
 }
 
 // The `SignatureBitStringEncoding` trait is used to convert a signature to a bit string. We implement

--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -35,6 +35,8 @@ fn main() {
     let data = certrequest.to_der().unwrap();
     let file_name_with_extension = "cert.csr";
     std::fs::write(file_name_with_extension, &data);
+
+    // TODO: The signature value of the generated csr is not correct.
 }
 
 // As mentioned in the README, we start by implementing the signature trait.

--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -17,6 +17,16 @@ use x509_cert::attr::Attributes;
 use x509_cert::name::RdnSequence;
 use x509_cert::request::CertReq;
 
+/// The following example uses the same setup as in ed25519_basic.rs, but in its main method, it
+/// creates a certificate signing request (CSR) and writes it to a file. The CSR is created from a
+/// polyproto ID CSR, which is a wrapper around a PKCS #10 CSR.
+///
+/// If you have openssl installed, you can inspect the CSR by running:
+///
+/// ```sh
+/// openssl req -in cert.csr -verify
+/// ```
+
 fn main() {
     let mut csprng = rand::rngs::OsRng;
     let priv_key = Ed25519PrivateKey::gen_keypair(&mut csprng);

--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -37,6 +37,8 @@ fn main() {
     std::fs::write(file_name_with_extension, &data);
 
     // TODO: The signature value of the generated csr is not correct.
+    // TODO: The attributes are still missing. CA Certificates and Actor Certificates should have
+    //       their respective set of capabilities
 }
 
 // As mentioned in the README, we start by implementing the signature trait.

--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -35,9 +35,8 @@ fn main() {
     println!("Certrequest der bytes: {:?}", certrequest.to_der().unwrap());
     let data = certrequest.to_der().unwrap();
     let file_name_with_extension = "cert.csr";
-    std::fs::write(file_name_with_extension, &data);
+    std::fs::write(file_name_with_extension, &data).unwrap();
 
-    // TODO: The signature value of the generated csr is not correct.
     // TODO: The attributes are still missing. CA Certificates and Actor Certificates should have
     //       their respective set of capabilities
 }

--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -25,9 +25,8 @@ fn main() {
     println!();
 
     let _csr = polyproto::certs::idcsr::IdCsr::new(
-        &RdnSequence::from_str("CN=flori,DC=www,DC=polyphony,DC=chat").unwrap(),
+        &RdnSequence::from_str("CN=flori,DC=www,DC=polyphony,DC=chat,UID=flori@polyphony.chat,uniqueIdentifier=client1").unwrap(),
         &priv_key,
-        &SessionId::new(Ia5String::try_from(String::from("value")).unwrap()).unwrap(),
         &Attributes::new(),
     )
     .unwrap();

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -5,9 +5,10 @@
 use std::marker::PhantomData;
 
 use der::asn1::{BitString, Uint};
-use der::{Decode, Encode, Length};
+use der::{Decode, Encode};
 use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
 use x509_cert::name::Name;
+use x509_cert::request::{CertReq, CertReqInfo};
 
 use crate::key::{PrivateKey, PublicKey};
 use crate::signature::Signature;
@@ -152,4 +153,33 @@ impl<S: Signature> IdCsrInner<S> {
     }
 }
 
-//TODO: Implement decode trait
+impl<S: Signature> From<CertReq> for IdCsr<S> {
+    fn from(value: CertReq) -> Self {
+        IdCsr {
+            inner_csr: IdCsrInner::from(value.info),
+            signature_algorithm: value.algorithm,
+            // TODO: raw_bytes() or as_bytes()?
+            signature: S::from_bitstring(value.signature.raw_bytes()),
+        }
+    }
+}
+
+// TODO Perhaps we should implement TryFrom instead of From, because the conversion can fail.
+impl<S: Signature> From<CertReqInfo> for IdCsrInner<S> {
+    fn from(value: CertReqInfo) -> Self {
+        todo!()
+    }
+}
+
+impl<S: Signature> From<IdCsr<S>> for CertReq {
+    fn from(value: IdCsr<S>) -> Self {
+        todo!()
+    }
+}
+
+// TODO Perhaps we should implement TryFrom instead of From, because the conversion can fail.
+impl<S: Signature> From<IdCsrInner<S>> for CertReqInfo {
+    fn from(value: IdCsrInner<S>) -> Self {
+        todo!()
+    }
+}

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -153,20 +153,23 @@ impl<S: Signature> IdCsrInner<S> {
     }
 }
 
-impl<S: Signature> From<CertReq> for IdCsr<S> {
-    fn from(value: CertReq) -> Self {
-        IdCsr {
-            inner_csr: IdCsrInner::from(value.info),
+impl<S: Signature> TryFrom<CertReq> for IdCsr<S> {
+    type Error = Error;
+
+    fn try_from(value: CertReq) -> Result<Self, Error> {
+        Ok(IdCsr {
+            inner_csr: IdCsrInner::try_from(value.info)?,
             signature_algorithm: value.algorithm,
             // TODO: raw_bytes() or as_bytes()?
             signature: S::from_bitstring(value.signature.raw_bytes()),
-        }
+        })
     }
 }
 
-// TODO Perhaps we should implement TryFrom instead of From, because the conversion can fail.
-impl<S: Signature> From<CertReqInfo> for IdCsrInner<S> {
-    fn from(value: CertReqInfo) -> Self {
+impl<S: Signature> TryFrom<CertReqInfo> for IdCsrInner<S> {
+    type Error = Error;
+
+    fn try_from(value: CertReqInfo) -> Result<Self, Self::Error> {
         todo!()
     }
 }
@@ -177,9 +180,10 @@ impl<S: Signature> From<IdCsr<S>> for CertReq {
     }
 }
 
-// TODO Perhaps we should implement TryFrom instead of From, because the conversion can fail.
-impl<S: Signature> From<IdCsrInner<S>> for CertReqInfo {
-    fn from(value: IdCsrInner<S>) -> Self {
+impl<S: Signature> TryFrom<IdCsrInner<S>> for CertReqInfo {
+    type Error = Error;
+
+    fn try_from(value: IdCsrInner<S>) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -152,49 +152,4 @@ impl<S: Signature> IdCsrInner<S> {
     }
 }
 
-impl<S: Signature> Encode for IdCsrInner<S> {
-    // TODO: Test this
-    fn encoded_len(&self) -> der::Result<Length> {
-        let len_version = Uint::new(&[self.version as u8])?.encoded_len()?;
-        let len_subject = self.subject.encoded_len()?;
-        let spki_converted: SubjectPublicKeyInfoOwned = self.subject_public_key_info.clone().into();
-        let len_spki = spki_converted.encoded_len()?;
-        let len_ssid = self.subject_session_id.as_attribute().encoded_len()?;
-        len_spki + len_subject + len_ssid + len_version
-    }
-
-    // TODO: Test this
-    fn encode(&self, encoder: &mut impl der::Writer) -> der::Result<()> {
-        let uint_version = Uint::new(&[self.version as u8])?;
-        let spki_converted: SubjectPublicKeyInfoOwned = self.subject_public_key_info.clone().into();
-        uint_version.encode(encoder)?;
-        self.subject.encode(encoder)?;
-        spki_converted.encode(encoder)?;
-        self.subject_session_id.as_attribute().encode(encoder)?;
-        Ok(())
-    }
-}
-
-impl<S: Signature> Encode for IdCsr<S> {
-    // TODO: Test this
-    fn encoded_len(&self) -> der::Result<Length> {
-        let len_inner = self.inner_csr.encoded_len()?;
-        let len_signature_algorithm = AlgorithmIdentifierOwned {
-            oid: self.signature_algorithm.oid,
-            parameters: self.signature_algorithm.parameters.clone(),
-        }
-        .encoded_len()?;
-        let len_signature = self.signature.to_bitstring()?.encoded_len()?;
-        len_inner + len_signature_algorithm + len_signature
-    }
-
-    // TODO: Test this
-    fn encode(&self, encoder: &mut impl der::Writer) -> der::Result<()> {
-        self.inner_csr.encode(encoder)?;
-        self.signature_algorithm.clone().encode(encoder)?;
-        self.signature.to_bitstring()?.encode(encoder)?;
-        Ok(())
-    }
-}
-
 //TODO: Implement decode trait

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -57,24 +57,20 @@ impl<S: Signature> IdCsr<S> {
     pub fn new(
         subject: &Name,
         signing_key: &impl PrivateKey<S>,
-        subject_session_id: &SessionId,
         attributes: &Attributes,
     ) -> Result<IdCsr<S>, Error> {
         subject.validate()?;
-        subject_session_id.validate()?;
         let inner_csr = IdCsrInner::<S>::new(subject, signing_key.pubkey(), attributes)?;
 
         let version_bytes = Uint::new(&[inner_csr.version as u8])?.to_der()?;
         let subject_bytes = inner_csr.subject.to_der()?;
         let spki_bytes =
             SubjectPublicKeyInfoOwned::from(inner_csr.subject_public_key_info.clone()).to_der()?;
-        let session_id_bytes = subject_session_id.to_der()?;
 
         let mut to_sign = Vec::new();
         to_sign.extend(version_bytes);
         to_sign.extend(subject_bytes);
         to_sign.extend(spki_bytes);
-        to_sign.extend(session_id_bytes);
 
         let signature = signing_key.sign(&to_sign);
         let signature_algorithm = S::algorithm_identifier();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@ pub(crate) mod value_constraints;
 
 use std::fmt::Debug;
 
+use openssl::error::ErrorStack;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Clone)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("Conversion from TbsCertificate to IdCertTbs failed")]
     TbsCertToIdCert(#[from] TbsCertToIdCert),
@@ -69,6 +70,8 @@ pub enum Error {
     InvalidInput(#[from] InvalidInput),
     #[error("Value failed to meet constraints")]
     ConstraintError(#[from] ConstraintError),
+    #[error("OpenSSL error")]
+    OpenSSL(#[from] ErrorStack),
 }
 
 /// Error type covering possible failures when converting a [x509_cert::TbsCertificate]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ pub(crate) mod value_constraints;
 
 use std::fmt::Debug;
 
-use openssl::error::ErrorStack;
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]
@@ -70,8 +69,6 @@ pub enum Error {
     InvalidInput(#[from] InvalidInput),
     #[error("Value failed to meet constraints")]
     ConstraintError(#[from] ConstraintError),
-    #[error("OpenSSL error")]
-    OpenSSL(#[from] ErrorStack),
 }
 
 /// Error type covering possible failures when converting a [x509_cert::TbsCertificate]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -11,4 +11,6 @@ pub trait Signature: PartialEq + Eq + SignatureBitStringEncoding {
     fn as_signature(&self) -> &Self::Signature;
     /// The [AlgorithmIdentifierOwned] associated with this signature
     fn algorithm_identifier() -> AlgorithmIdentifierOwned;
+    /// From a bit string signature value, create a new [Self]
+    fn from_bitstring(signature: &[u8]) -> Self;
 }


### PR DESCRIPTION
This PR uses the `x509-cert` and the progress made in #4 and #3 to create an example of a valid, signed PKCS #10 CSR and write it to disk in DER encoding. OpenSSL can then be used on the host machine to verify the validity of this CSR:

```sh
[star@arch polyproto-rs]$ openssl req -in cert.csr -verify 
Certificate request self-signature verify OK
-----BEGIN CERTIFICATE REQUEST-----
MIIBFjCByQIBADCBlTEXMBUGCgmSJomT8ixkASwMB2NsaWVudDExJDAiBgoJkiaJ
k/IsZAEBDBRmbG9yaUBwb2x5cGhvbnkuY2hhdDEUMBIGCgmSJomT8ixkARkWBGNo
YXQxGTAXBgoJkiaJk/IsZAEZFglwb2x5cGhvbnkxEzARBgoJkiaJk/IsZAEZFgN3
d3cxDjAMBgNVBAMMBWZsb3JpMCowBQYDK2VwAyEAN9ySQNCy6fSb2HT0oa6tnbUM
9kOm0ePJO0DAZZQmi1igADAFBgMrZXADQQAybiky7DaqMLe91H/ztdMTQiEhyPCg
SQtayesr0OLrZdbifc6VnuIp6ZtcmPeJ4PRHXkBWXi0BC9Q5ma7h8PwL
-----END CERTIFICATE REQUEST-----
```

or, using LibreSSL 3.8.2 instead

```sh
❯ openssl req -in cert.csr -inform der -verify 
verify OK
-----BEGIN CERTIFICATE REQUEST-----
MIIBFjCByQIBADCBlTEXMBUGCgmSJomT8ixkASwMB2NsaWVudDExJDAiBgoJkiaJ
k/IsZAEBDBRmbG9yaUBwb2x5cGhvbnkuY2hhdDEUMBIGCgmSJomT8ixkARkWBGNo
YXQxGTAXBgoJkiaJk/IsZAEZFglwb2x5cGhvbnkxEzARBgoJkiaJk/IsZAEZFgN3
d3cxDjAMBgNVBAMMBWZsb3JpMCowBQYDK2VwAyEATBJKeC2JjvWTEEdR9QFgYdun
LaxFxF8xEXwkZ6xgvuOgADAFBgMrZXADQQB6xxfj0RQhrU4Z79+++u+Jq+P32q07
4iqYbgcm0qCVtyuascfkPULQEmG4wHDJaI2I+yrYvhuGDvXBDAUxlu8E
-----END CERTIFICATE REQUEST-----
```


As can be seen above, an example implementation of the traits offered by the polyproto-crate with the `ed25519-dalek` crate produces a valid CSR.