### PR TITLE
Validate attributes extensions

### DIFF
--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -49,9 +49,6 @@ fn main() {
     let file_name_with_extension = "cert.csr";
     #[cfg(not(target_arch = "wasm32"))]
     std::fs::write(file_name_with_extension, &data).unwrap();
-
-    // TODO: The attributes are still missing. CA Certificates and Actor Certificates should have
-    //       their respective set of capabilities
 }
 
 // As mentioned in the README, we start by implementing the signature trait.

--- a/src/certs/capabilities.rs
+++ b/src/certs/capabilities.rs
@@ -9,7 +9,7 @@ use der::Any;
 use spki::ObjectIdentifier;
 use x509_cert::attr::Attribute;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Capabilities which an ID-Cert or ID-CSR might have. For ID-Certs, you'd find these capabilities
 /// in the `Extensions` field of a certificate. ID-CSRs store these capabilities as part of the
 /// `Attributes` field.
@@ -21,7 +21,7 @@ pub struct Capabilities {
     pub key_usage: Vec<KeyUsage>,
     /// Extension type that defines whether a given certificate is allowed
     /// to sign additional certificates and what path length restrictions may exist.
-    pub basic_constraints: Vec<BasicConstraints>,
+    pub basic_constraints: BasicConstraints,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/certs/capabilities.rs
+++ b/src/certs/capabilities.rs
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+/// Capabilities which an ID-Cert or ID-CSR might have. For ID-Certs, you'd find these capabilities
+/// in the `Extensions` field of a certificate. ID-CSRs store these capabilities as part of the
+/// `Attributes` field.
+///
+/// This struct only covers the CertCapability subtype trees of which at least one of the subtypes
+/// are relevant to polyproto certificates.
+pub struct CertCapabilities {
+    /// The key usage extension defines the purpose of the key contained in the certificate.
+    pub key_usage: Vec<KeyUsage>,
+    /// Extension type that defines whether a given certificate is allowed
+    /// to sign additional certificates and what path length restrictions may exist.
+    pub basic_constraints: Vec<BasicConstraints>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// The key usage extension defines the purpose of the key contained in the certificate. The usage
+/// restriction might be employed when a key that could be used for more than one operation is to
+/// be restricted. See <https://cryptography.io/en/latest/x509/reference/#cryptography.x509.KeyUsage>
+pub enum KeyUsage {
+    /// This purpose is set to true when the subject public key is used for verifying digital
+    /// signatures, other than signatures on certificates (`key_cert_sign`) and CRLs (`crl_sign`).
+    DigitalSignature(bool),
+    /// This purpose is set to true when the subject public key is used for verifying signatures on
+    /// certificate revocation lists.
+    CrlSign(bool),
+    /// This purpose is set to true when the subject public key is used for verifying digital
+    /// signatures, other than signatures on certificates (`key_cert_sign`) and CRLs (`crl_sign`).
+    /// It is used to provide a non-repudiation service that protects against the signing entity
+    /// falsely denying some action. In the case of later conflict, a reliable third party may
+    /// determine the authenticity of the signed data. This was called `non_repudiation` in older
+    /// revisions of the X.509 specification.
+    ContentCommitment(bool),
+    /// This purpose is set to true when the subject public key is used for enciphering private or
+    /// secret keys.
+    KeyEncipherment(bool),
+    /// This purpose is set to true when the subject public key is used for directly enciphering raw
+    /// user data without the use of an intermediate symmetric cipher.
+    DataEncipherment(bool),
+    /// This purpose is set to true when the subject public key is used for key agreement. For
+    /// example, when a Diffie-Hellman key is to be used for key management, then this purpose is
+    /// set to true.
+    KeyAgreement(bool),
+    /// This purpose is set to true when the subject public key is used for verifying signatures on
+    /// public key certificates. If this purpose is set to true then ca must be true in the
+    /// `BasicConstraints` extension.
+    KeyCertSign(bool),
+    /// When this purposes is set to true and the `key_agreement` purpose is also set, the subject
+    /// public key may be used only for enciphering data while performing key agreement. The
+    /// `KeyAgreement` capability must be set to `true` for this.
+    EncipherOnly(bool),
+    /// When this purposes is set to true and the `key_agreement` purpose is also set, the subject
+    /// public key may be used only for deciphering data while performing key agreement. The
+    /// `KeyAgreement` capability must be set to `true` for this.
+    DecipherOnly(bool),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Basic constraints is an X.509 extension type that defines whether a given certificate is allowed
+/// to sign additional certificates and what path length restrictions may exist.
+pub enum BasicConstraints {
+    /// Whether the certificate can sign certificates.
+    Ca(bool),
+    /// The maximum path length for certificates subordinate to this certificate. This attribute
+    /// only has meaning if `ca` is true. If `ca` is true then a path length of None means there’s no
+    /// restriction on the number of subordinate CAs in the certificate chain. If it is zero or
+    /// greater then it defines the maximum length for a subordinate CA’s certificate chain. For
+    /// example, a `path_length` of 1 means the certificate can sign a subordinate CA, but the
+    /// subordinate CA is not allowed to create subordinates with `ca` set to true.
+    PathLength(Option<u64>),
+}

--- a/src/certs/capabilities.rs
+++ b/src/certs/capabilities.rs
@@ -9,7 +9,7 @@
 ///
 /// This struct only covers the CertCapability subtype trees of which at least one of the subtypes
 /// are relevant to polyproto certificates.
-pub struct CertCapabilities {
+pub struct Capabilities {
     /// The key usage extension defines the purpose of the key contained in the certificate.
     pub key_usage: Vec<KeyUsage>,
     /// Extension type that defines whether a given certificate is allowed

--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -5,10 +5,18 @@
 use std::ops::{Deref, DerefMut};
 
 use der::asn1::{BitString, Ia5String};
-use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
+use der::Any;
+use spki::{AlgorithmIdentifierOwned, ObjectIdentifier, SubjectPublicKeyInfoOwned};
+use x509_cert::attr::Attribute;
+use x509_cert::ext::Extension;
 
 use crate::{Constrained, ConstraintError};
 
+use self::capabilities::CertCapabilities;
+
+/// Additional capabilities ([x509_cert::ext::Extensions] or [x509_cert::attr::Attributes], depending
+/// on the context) of X.509 certificates.
+pub mod capabilities;
 /// Complete, signed [IdCert]
 pub mod idcert;
 /// [IdCertTbs] is an [IdCert] which has not yet been signed by
@@ -103,5 +111,41 @@ impl From<PublicKeyInfo> for SubjectPublicKeyInfoOwned {
             algorithm: value.algorithm,
             subject_public_key: value.public_key_bitstring,
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtensionOrAttribute {
+    oid: ObjectIdentifier,
+    critical: bool,
+    value: Any,
+}
+impl ExtensionOrAttribute {
+    pub fn build(capabilities: &CertCapabilities) -> Result<&[Self], crate::Error> {
+        let validated = capabilities.validate();
+        if validated.is_err() {
+            return Err(crate::Error::ConstraintError(ConstraintError::Malformed));
+        }
+        todo!()
+    }
+
+    pub fn oid(&self) -> &ObjectIdentifier {
+        &self.oid
+    }
+
+    pub fn critical(&self) -> bool {
+        self.critical
+    }
+
+    pub fn value(&self) -> &Any {
+        &self.value
+    }
+
+    pub fn to_extension(&self) -> Extension {
+        todo!()
+    }
+
+    pub fn to_attribute(&self) -> Attribute {
+        todo!()
     }
 }

--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -12,7 +12,7 @@ use x509_cert::ext::Extension;
 
 use crate::{Constrained, ConstraintError};
 
-use self::capabilities::CertCapabilities;
+use self::capabilities::Capabilities;
 
 /// Additional capabilities ([x509_cert::ext::Extensions] or [x509_cert::attr::Attributes], depending
 /// on the context) of X.509 certificates.
@@ -121,7 +121,7 @@ pub struct ExtensionOrAttribute {
     value: Any,
 }
 impl ExtensionOrAttribute {
-    pub fn build(capabilities: &CertCapabilities) -> Result<&[Self], crate::Error> {
+    pub fn build(capabilities: &Capabilities) -> Result<&[Self], crate::Error> {
         let validated = capabilities.validate();
         if validated.is_err() {
             return Err(crate::Error::ConstraintError(ConstraintError::Malformed));

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -5,7 +5,7 @@
 use der::Length;
 use x509_cert::name::Name;
 
-use crate::certs::capabilities::{BasicConstraints, Capabilities, KeyUsage};
+use crate::certs::capabilities::{Capabilities, KeyUsage};
 use crate::certs::SessionId;
 use crate::Constrained;
 
@@ -204,7 +204,6 @@ mod name_constraints {
 
 #[cfg(test)]
 mod session_id_constraints {
-    use der::asn1::Ia5String;
 
     use crate::certs::SessionId;
 

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -108,6 +108,9 @@ impl Constrained for SessionId {
     }
 }
 
+// TODO: The attributes are still missing. CA Certificates and Actor Certificates should have
+//       their respective set of capabilities
+
 #[cfg(test)]
 mod name_constraints {
     use std::str::FromStr;

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -5,7 +5,7 @@
 use der::Length;
 use x509_cert::name::Name;
 
-use crate::certs::capabilities::{BasicConstraints, CertCapabilities, KeyUsage};
+use crate::certs::capabilities::{BasicConstraints, Capabilities, KeyUsage};
 use crate::certs::SessionId;
 use crate::Constrained;
 
@@ -112,7 +112,7 @@ impl Constrained for SessionId {
 // TODO: The attributes are still missing. CA Certificates and Actor Certificates should have
 //       their respective set of capabilities
 
-impl Constrained for CertCapabilities {
+impl Constrained for Capabilities {
     fn validate(&self) -> Result<(), crate::ConstraintError> {
         let mut has_only_encipher = false;
         let mut has_only_decipher = false;


### PR DESCRIPTION
This partially implements #8. A validation method exists for a newly defined `Capabilities` type, which checks for the constraints defined in the polyproto specification. However, IdCsrs and IdCerts are not yet being validated. 