### PR TITLE
Untangle Error Type

### DIFF
--- a/examples/ed25519_basic.rs
+++ b/examples/ed25519_basic.rs
@@ -60,9 +60,6 @@ fn main() {
     )
 }
 
-#[cfg(not(test))]
-fn main() {}
-
 // As mentioned in the README, we start by implementing the signature trait.
 
 // Here, we start by defining the signature type, which is a wrapper around the signature type from

--- a/examples/ed25519_csr.rs
+++ b/examples/ed25519_csr.rs
@@ -54,9 +54,6 @@ fn main() {
     std::fs::write(file_name_with_extension, &data).unwrap();
 }
 
-#[cfg(not(test))]
-fn main() {}
-
 // As mentioned in the README, we start by implementing the signature trait.
 
 // Here, we start by defining the signature type, which is a wrapper around the signature type from

--- a/src/certs/capabilities/basic_constraints.rs
+++ b/src/certs/capabilities/basic_constraints.rs
@@ -9,7 +9,7 @@ use der::{Any, Tag, Tagged};
 use spki::ObjectIdentifier;
 use x509_cert::attr::Attribute;
 
-use crate::errors::composite::InvalidInput;
+use crate::errors::base::InvalidInput;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 /// Basic constraints is an X.509 extension type that defines whether a given certificate is allowed

--- a/src/certs/capabilities/basic_constraints.rs
+++ b/src/certs/capabilities/basic_constraints.rs
@@ -9,7 +9,7 @@ use der::{Any, Tag, Tagged};
 use spki::ObjectIdentifier;
 use x509_cert::attr::Attribute;
 
-use crate::Error;
+use crate::errors::composite::InvalidInput;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 /// Basic constraints is an X.509 extension type that defines whether a given certificate is allowed
@@ -33,7 +33,7 @@ impl From<BasicConstraints> for ObjectIdentifier {
 }
 
 impl TryFrom<Attribute> for BasicConstraints {
-    type Error = Error;
+    type Error = InvalidInput;
     /// Performs the conversion.
     ///
     /// Fails, if the input attribute
@@ -44,25 +44,21 @@ impl TryFrom<Attribute> for BasicConstraints {
     fn try_from(value: Attribute) -> Result<Self, Self::Error> {
         // Basic input validation. Check OID of Attribute and length of the "values" SetOfVec provided.
         if value.oid.to_string() != super::OID_BASIC_CONSTRAINTS {
-            return Err(Error::InvalidInput(
-                crate::InvalidInput::IncompatibleVariantForConversion {
-                    reason: format!(
-                        "OID of value does not match any of OID_BASIC_CONSTRAINTS. Found OID {}",
-                        value.oid
-                    ),
-                },
-            ));
+            return Err(Self::Error::IncompatibleVariantForConversion {
+                reason: format!(
+                    "OID of value does not match any of OID_BASIC_CONSTRAINTS. Found OID {}",
+                    value.oid
+                ),
+            });
         }
         let values = value.values;
         if values.len() > 2usize {
-            return Err(Error::InvalidInput(
-                crate::InvalidInput::IncompatibleVariantForConversion {
-                    reason: format!(
-                        "Expected 1 or 2 values for BasicConstraints, found {}",
-                        values.len()
-                    ),
-                },
-            ));
+            return Err(InvalidInput::IncompatibleVariantForConversion {
+                reason: format!(
+                    "Expected 1 or 2 values for BasicConstraints, found {}",
+                    values.len()
+                ),
+            });
         }
         let mut num_ca = 0u8;
         let mut num_path_length = 0u8;
@@ -78,15 +74,15 @@ impl TryFrom<Attribute> for BasicConstraints {
                             &[0x00] => false,
                             &[0xFF] | &[0x01] => true,
                             _ => {
-                                return Err(Error::InvalidInput(
-                                    crate::InvalidInput::IncompatibleVariantForConversion {
+                                return Err(
+                                    InvalidInput::IncompatibleVariantForConversion {
                                         reason: "Encountered unexpected value for Boolean tag".to_string(),
                                     },
-                                ))
+                                )
                             }
                         }
                     } else {
-                        return Err(Error::InvalidInput(crate::InvalidInput::IncompatibleVariantForConversion { reason: "Encountered > 1 Boolean tags. Expected 1 Boolean tag.".to_string() }));
+                        return Err(InvalidInput::IncompatibleVariantForConversion { reason: "Encountered > 1 Boolean tags. Expected 1 Boolean tag.".to_string() });
                     }
                 }
                 Tag::Integer => {
@@ -100,18 +96,16 @@ impl TryFrom<Attribute> for BasicConstraints {
                         buf[..len].copy_from_slice(value.value());
                         path_length = Some(u64::from_be_bytes(buf));
                     } else {
-                        return Err(Error::InvalidInput(crate::InvalidInput::IncompatibleVariantForConversion { reason: "Encountered > 1 Integer tags. Expected 0 or 1 Integer tags.".to_string() }));
+                        return Err(InvalidInput::IncompatibleVariantForConversion { reason: "Encountered > 1 Integer tags. Expected 0 or 1 Integer tags.".to_string() });
                     }
                 }
-                _ => return Err(Error::InvalidInput(crate::InvalidInput::IncompatibleVariantForConversion { reason: format!("Encountered unexpected tag {:?}, when tag should have been either Boolean or Integer", value.tag()) })),
+                _ => return Err(InvalidInput::IncompatibleVariantForConversion { reason: format!("Encountered unexpected tag {:?}, when tag should have been either Boolean or Integer", value.tag()) }),
             }
         }
         if num_ca == 0 {
-            return Err(Error::InvalidInput(
-                crate::InvalidInput::IncompatibleVariantForConversion {
-                    reason: "Expected 1 Boolean tag, found 0".to_string(),
-                },
-            ));
+            return Err(InvalidInput::IncompatibleVariantForConversion {
+                reason: "Expected 1 Boolean tag, found 0".to_string(),
+            });
         }
         Ok(BasicConstraints { ca, path_length })
     }

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -9,7 +9,7 @@ use der::{Any, Tag, Tagged};
 use spki::ObjectIdentifier;
 use x509_cert::attr::Attribute;
 
-use crate::errors::composite::InvalidInput;
+use crate::errors::base::InvalidInput;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// The key usage extension defines the purpose of the key contained in the certificate. The usage

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -13,7 +13,7 @@ use der::asn1::SetOfVec;
 
 use x509_cert::attr::{Attribute, Attributes};
 
-use crate::errors::composite::InvalidInput;
+use crate::errors::base::InvalidInput;
 use crate::{Constrained, ConstraintError};
 
 /// Object Identifier for the KeyUsage::DigitalSignature variant.

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -13,7 +13,8 @@ use der::asn1::SetOfVec;
 
 use x509_cert::attr::{Attribute, Attributes};
 
-use crate::{Constrained, ConstraintError, Error};
+use crate::errors::composite::InvalidInput;
+use crate::{Constrained, ConstraintError};
 
 /// Object Identifier for the KeyUsage::DigitalSignature variant.
 pub const OID_KEY_USAGE_DIGITAL_SIGNATURE: &str = "1.3.6.1.5.5.7.3.3";
@@ -93,7 +94,7 @@ impl Capabilities {
 }
 
 impl TryFrom<Attributes> for Capabilities {
-    type Error = Error;
+    type Error = InvalidInput;
 
     /// Performs the conversion.
     ///
@@ -122,7 +123,7 @@ impl TryFrom<Attributes> for Capabilities {
                 OID_BASIC_CONSTRAINTS => {
                     num_basic_constraints += 1;
                     if num_basic_constraints > 1 {
-                        return Err(Error::InvalidInput(crate::InvalidInput::IncompatibleVariantForConversion { reason: "Tried inserting > 1 BasicConstraints into Capabilities. Expected 1 BasicConstraints".to_string() }));
+                        return Err(InvalidInput::IncompatibleVariantForConversion { reason: "Tried inserting > 1 BasicConstraints into Capabilities. Expected 1 BasicConstraints".to_string() });
                     } else {
                         basic_constraints = BasicConstraints::try_from(item.clone())?;
                     }

--- a/src/certs/idcerttbs.rs
+++ b/src/certs/idcerttbs.rs
@@ -64,19 +64,19 @@ impl<P: Profile> TryFrom<TbsCertificateInner<P>> for IdCertTbs {
         value.subject.validate()?;
         let subject_unique_id = match value.subject_unique_id {
             Some(suid) => suid,
-            None => return Err(TbsCertToIdCert::SubjectUid.into()),
+            None => return Err(TbsCertToIdCert::SubjectUid),
         };
 
         let extensions = match value.extensions {
             Some(ext) => ext,
-            None => return Err(TbsCertToIdCert::Extensions.into()),
+            None => return Err(TbsCertToIdCert::Extensions),
         };
 
         let subject_public_key_info = PublicKeyInfo::from(value.subject_public_key_info);
 
         let serial_number = match Uint::new(value.serial_number.as_bytes()) {
             Ok(snum) => snum,
-            Err(e) => return Err(TbsCertToIdCert::Signature(e).into()),
+            Err(e) => return Err(TbsCertToIdCert::Signature(e)),
         };
 
         Ok(IdCertTbs {

--- a/src/certs/idcerttbs.rs
+++ b/src/certs/idcerttbs.rs
@@ -11,7 +11,8 @@ use x509_cert::name::Name;
 use x509_cert::serial_number::SerialNumber;
 use x509_cert::time::Validity;
 
-use crate::{Constrained, Error, IdCertToTbsCert, TbsCertToIdCert};
+use crate::errors::composite::{IdCertToTbsCert, TbsCertToIdCert};
+use crate::Constrained;
 
 use super::PublicKeyInfo;
 
@@ -57,7 +58,7 @@ pub struct IdCertTbs {
 }
 
 impl<P: Profile> TryFrom<TbsCertificateInner<P>> for IdCertTbs {
-    type Error = Error;
+    type Error = TbsCertToIdCert;
 
     fn try_from(value: TbsCertificateInner<P>) -> Result<Self, Self::Error> {
         value.subject.validate()?;

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -11,6 +11,7 @@ use x509_cert::attr::Attributes;
 use x509_cert::name::Name;
 use x509_cert::request::{CertReq, CertReqInfo};
 
+use crate::errors::composite::{IdCsrError, IdCsrInnerError};
 use crate::key::{PrivateKey, PublicKey};
 use crate::signature::Signature;
 use crate::{Constrained, ConstraintError};
@@ -62,7 +63,7 @@ impl<S: Signature> IdCsr<S> {
         subject: &Name,
         signing_key: &impl PrivateKey<S>,
         capabilities: &Capabilities,
-    ) -> Result<IdCsr<S>, ConstraintError> {
+    ) -> Result<IdCsr<S>, IdCsrError> {
         subject.validate()?;
         let inner_csr = IdCsrInner::<S>::new(subject, signing_key.pubkey(), capabilities)?;
         let cert_req_info = CertReqInfo::try_from(inner_csr)?;
@@ -119,12 +120,12 @@ impl<S: Signature> IdCsr<S> {
     }
 
     /// Create an IdCsr from a byte slice containing a DER encoded PKCS #10 CSR.
-    pub fn from_der(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_der(bytes: &[u8]) -> Result<Self, IdCsrError> {
         IdCsr::try_from(CertReq::from_der(bytes)?)
     }
 
     /// Encode this type as DER, returning a byte vector.
-    pub fn to_der(self) -> Result<Vec<u8>, Error> {
+    pub fn to_der(self) -> Result<Vec<u8>, IdCsrError> {
         Ok(CertReq::try_from(self)?.to_der()?)
     }
 }
@@ -161,7 +162,7 @@ impl<S: Signature> IdCsrInner<S> {
         subject: &Name,
         public_key: &impl PublicKey<S>,
         capabilities: &Capabilities,
-    ) -> Result<IdCsrInner<S>, Error> {
+    ) -> Result<IdCsrInner<S>, IdCsrInnerError> {
         subject.validate()?;
         capabilities.validate()?;
 
@@ -184,20 +185,20 @@ impl<S: Signature> IdCsrInner<S> {
     }
 
     /// Create an IdCsrInner from a byte slice containing a DER encoded PKCS #10 CSR.
-    pub fn from_der(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_der(bytes: &[u8]) -> Result<Self, IdCsrInnerError> {
         IdCsrInner::try_from(CertReqInfo::from_der(bytes)?)
     }
 
     /// Encode this type as DER, returning a byte vector.
-    pub fn to_der(self) -> Result<Vec<u8>, Error> {
+    pub fn to_der(self) -> Result<Vec<u8>, IdCsrInnerError> {
         Ok(CertReqInfo::try_from(self)?.to_der()?)
     }
 }
 
 impl<S: Signature> TryFrom<CertReq> for IdCsr<S> {
-    type Error = Error;
+    type Error = IdCsrError;
 
-    fn try_from(value: CertReq) -> Result<Self, Error> {
+    fn try_from(value: CertReq) -> Result<Self, Self::Error> {
         Ok(IdCsr {
             inner_csr: IdCsrInner::try_from(value.info)?,
             signature_algorithm: value.algorithm,
@@ -208,7 +209,7 @@ impl<S: Signature> TryFrom<CertReq> for IdCsr<S> {
 }
 
 impl<S: Signature> TryFrom<CertReqInfo> for IdCsrInner<S> {
-    type Error = Error;
+    type Error = IdCsrInnerError;
 
     fn try_from(value: CertReqInfo) -> Result<Self, Self::Error> {
         let rdn_sequence = value.subject;
@@ -229,7 +230,7 @@ impl<S: Signature> TryFrom<CertReqInfo> for IdCsrInner<S> {
 }
 
 impl<S: Signature> TryFrom<IdCsr<S>> for CertReq {
-    type Error = Error;
+    type Error = IdCsrError;
 
     fn try_from(value: IdCsr<S>) -> Result<Self, Self::Error> {
         Ok(CertReq {
@@ -241,7 +242,7 @@ impl<S: Signature> TryFrom<IdCsr<S>> for CertReq {
 }
 
 impl<S: Signature> TryFrom<IdCsrInner<S>> for CertReqInfo {
-    type Error = Error;
+    type Error = IdCsrInnerError;
     fn try_from(value: IdCsrInner<S>) -> Result<Self, Self::Error> {
         Ok(CertReqInfo {
             version: x509_cert::request::Version::V1,

--- a/src/errors/base.rs
+++ b/src/errors/base.rs
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/errors/base.rs
+++ b/src/errors/base.rs
@@ -1,3 +1,18 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum ConstraintError {
+    #[error("The value did not meet the set validation criteria and is considered malformed")]
+    Malformed(Option<String>),
+    #[error("The value was expected to be between {lower:?} and {upper:?} but was {actual:?}")]
+    OutOfBounds {
+        lower: i32,
+        upper: i32,
+        actual: String,
+        reason: Option<String>,
+    },
+}

--- a/src/errors/base.rs
+++ b/src/errors/base.rs
@@ -16,3 +16,27 @@ pub enum ConstraintError {
         reason: Option<String>,
     },
 }
+
+/// Represents errors for invalid input in IdCsr or IdCert generation.
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum InvalidInput {
+    #[error("The der library has reported the following error with the input")]
+    DerError(der::Error),
+    #[error("subject_session_id MUST NOT exceed length limit of 32 characters")]
+    SessionIdTooLong,
+    #[error(
+        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
+    )]
+    IncompatibleVariantForConversion { reason: String },
+}
+
+#[derive(Error, Debug, PartialEq, Clone)]
+// TODO: Replace usages of InvalidInput::IncompatibleVariantForConversion with this Enum
+pub enum UnsuccessfulConversion {
+    #[error(
+        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
+    )]
+    IncompatibleVariant { reason: String },
+    #[error("Conversion failed due to invalid input")]
+    InvalidInput(String),
+}

--- a/src/errors/composite.rs
+++ b/src/errors/composite.rs
@@ -1,0 +1,3 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/errors/composite.rs
+++ b/src/errors/composite.rs
@@ -71,3 +71,59 @@ impl From<der::Error> for InvalidInput {
         Self::DerError(value)
     }
 }
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum CertReqToIdCsr {
+    #[error(transparent)]
+    CertReqInfoToIdCsrInner(#[from] CertReqInfoError),
+}
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum CertReqInfoError {
+    #[error(transparent)]
+    ConstraintError(#[from] ConstraintError),
+    #[error(transparent)]
+    InvalidInput(#[from] InvalidInput),
+    #[error("Couldn't parse CertReqInfo from provided DER bytes")]
+    DerError(der::Error),
+    #[error(transparent)]
+    MalformedIdCsrInner(#[from] IdCsrInnerError),
+}
+
+impl From<der::Error> for CertReqInfoError {
+    fn from(value: der::Error) -> Self {
+        Self::DerError(value)
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum IdCsrError {
+    #[error("The Bitstring is invalid")]
+    InvalidBitstring(der::Error),
+    #[error(transparent)]
+    IdCsrInnerToCertReqInfo(#[from] IdCsrInnerError),
+    #[error(transparent)]
+    ConstraintError(#[from] ConstraintError),
+}
+
+impl From<der::Error> for IdCsrError {
+    fn from(value: der::Error) -> Self {
+        Self::InvalidBitstring(value)
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum IdCsrInnerError {
+    #[error(transparent)]
+    ConstraintError(#[from] ConstraintError),
+    #[error("Encountered DER encoding error")]
+    DerError(der::Error),
+    #[error(transparent)]
+    InvalidInput(#[from] InvalidInput),
+}
+
+impl From<der::Error> for IdCsrInnerError {
+    fn from(value: der::Error) -> Self {
+        Self::DerError(value)
+    }
+}

--- a/src/errors/composite.rs
+++ b/src/errors/composite.rs
@@ -4,7 +4,7 @@
 
 use thiserror::Error;
 
-use super::base::ConstraintError;
+use super::base::{ConstraintError, InvalidInput};
 
 /// Error type covering possible failures when converting a [x509_cert::TbsCertificate]
 /// to a [crate::cert::IdCertTbs]
@@ -26,30 +26,6 @@ pub enum TbsCertToIdCert {
 pub enum IdCertToTbsCert {
     #[error("Serial number could not be converted")]
     SerialNumber(der::Error),
-}
-
-/// Represents errors for invalid input in IdCsr or IdCert generation.
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum InvalidInput {
-    #[error("The der library has reported the following error with the input")]
-    DerError(der::Error),
-    #[error("subject_session_id MUST NOT exceed length limit of 32 characters")]
-    SessionIdTooLong,
-    #[error(
-        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
-    )]
-    IncompatibleVariantForConversion { reason: String },
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-// TODO: Replace usages of InvalidInput::IncompatibleVariantForConversion with this Enum
-pub enum UnsuccessfulConversion {
-    #[error(
-        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
-    )]
-    IncompatibleVariant { reason: String },
-    #[error("Conversion failed due to invalid input")]
-    InvalidInput(String),
 }
 
 #[derive(Error, Debug, PartialEq, Clone)]

--- a/src/errors/composite.rs
+++ b/src/errors/composite.rs
@@ -1,3 +1,73 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use thiserror::Error;
+
+use super::base::ConstraintError;
+
+/// Error type covering possible failures when converting a [x509_cert::TbsCertificate]
+/// to a [crate::cert::IdCertTbs]
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum TbsCertToIdCert {
+    #[error("field 'subject_unique_id' was None. Expected: Some(der::asn1::BitString)")]
+    SubjectUid,
+    #[error("field 'extensions' was None. Expected: Some(x509_cert::ext::Extensions)")]
+    Extensions,
+    #[error("Supplied integer too long")]
+    Signature(der::Error),
+    #[error(transparent)]
+    Constraint(#[from] ConstraintError),
+}
+
+/// Error type covering possible failures when converting a [crate::cert::IdCertTbs]
+/// to a [x509_cert::TbsCertificate]
+#[derive(Error, Debug, PartialEq, Clone, Copy)]
+pub enum IdCertToTbsCert {
+    #[error("Serial number could not be converted")]
+    SerialNumber(der::Error),
+}
+
+/// Represents errors for invalid input in IdCsr or IdCert generation.
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum InvalidInput {
+    #[error("The der library has reported the following error with the input")]
+    DerError(der::Error),
+    #[error("subject_session_id MUST NOT exceed length limit of 32 characters")]
+    SessionIdTooLong,
+    #[error(
+        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
+    )]
+    IncompatibleVariantForConversion { reason: String },
+}
+
+#[derive(Error, Debug, PartialEq, Clone)]
+// TODO: Replace usages of InvalidInput::IncompatibleVariantForConversion with this Enum
+pub enum UnsuccessfulConversion {
+    #[error(
+        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
+    )]
+    IncompatibleVariant { reason: String },
+    #[error("Conversion failed due to invalid input")]
+    InvalidInput(String),
+}
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum InvalidCert {
+    #[error("The signature does not match the contents of the certificate")]
+    InvalidSignature,
+    #[error("The subject presented on the certificate is malformed or otherwise invalid")]
+    InvalidSubject(ConstraintError),
+    #[error("The issuer presented on the certificate is malformed or otherwise invalid")]
+    InvalidIssuer(ConstraintError),
+    #[error("The validity period of the certificate is invalid, or the certificate is expired")]
+    InvalidValidity,
+    #[error("The capabilities presented on the certificate are invalid or otherwise malformed")]
+    InvalidCapabilities(ConstraintError),
+}
+
+impl From<der::Error> for InvalidInput {
+    fn from(value: der::Error) -> Self {
+        Self::DerError(value)
+    }
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -6,3 +6,8 @@
 pub mod base;
 /// "Composite" error types which consist of one or more "base" error types
 pub mod composite;
+
+// TODO
+// PRETTYFYME
+// This module can be restructured to be a reflection of the src/ file tree. It would then be very
+// easy to tell, which file covers error types of which data types

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// "Base" error types which can be combined into "composite" error types
+pub mod base;
+/// "Composite" error types which consist of one or more "base" error types
+pub mod composite;


### PR DESCRIPTION
Closes #16 

This PR gives each data type with fallible methods its own error data type. The idea here is to minimize how many error variants you have to, for example, match for when trying to deal with these errors in other code.