### PR TITLE
Fix KeyUsage/KeyUsages

### DIFF
--- a/examples/ed25519_cert.rs
+++ b/examples/ed25519_cert.rs
@@ -56,9 +56,7 @@ fn main() {
         &Capabilities::default_actor(),
     )
     .unwrap();
-
     let data = csr.clone().to_der().unwrap();
-    dbg!(&data);
     let file_name_with_extension = "cert.csr";
     #[cfg(not(target_arch = "wasm32"))]
     std::fs::write(file_name_with_extension, &data).unwrap();

--- a/examples/ed25519_from_der.rs
+++ b/examples/ed25519_from_der.rs
@@ -1,0 +1,229 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#![allow(unused)]
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use der::asn1::{BitString, Ia5String, Uint, UtcTime};
+use der::{Decode, Encode};
+use ed25519_dalek::{Signature as Ed25519DalekSignature, Signer, SigningKey, VerifyingKey};
+use polyproto::certs::capabilities::Capabilities;
+use polyproto::certs::idcert::IdCert;
+use polyproto::certs::PublicKeyInfo;
+use polyproto::key::{PrivateKey, PublicKey};
+use polyproto::signature::Signature;
+use rand::rngs::OsRng;
+use spki::{AlgorithmIdentifierOwned, ObjectIdentifier, SignatureBitStringEncoding};
+use thiserror::Error;
+use x509_cert::attr::Attributes;
+use x509_cert::name::RdnSequence;
+use x509_cert::request::CertReq;
+use x509_cert::time::{Time, Validity};
+use x509_cert::Certificate;
+
+/// The following example uses the same setup as in ed25519_basic.rs, but in its main method, it
+/// creates a certificate signing request (CSR) and writes it to a file. The CSR is created from a
+/// polyproto ID CSR, which is a wrapper around a PKCS #10 CSR.
+///
+/// If you have openssl installed, you can inspect the CSR by running:
+///
+/// ```sh
+/// openssl req -in cert.csr -verify -inform der
+/// ```
+///
+/// After that, the program creates an ID-Cert from the given ID-CSR. The `cert.der` file can also
+/// be validated using openssl:
+///
+/// ```sh
+/// openssl x509 -in cert.der -text -noout -inform der
+/// ```
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+fn main() {
+    let mut csprng = rand::rngs::OsRng;
+    let priv_key = Ed25519PrivateKey::gen_keypair(&mut csprng);
+    println!("Private Key is: {:?}", priv_key.key.to_bytes());
+    println!("Public Key is: {:?}", priv_key.public_key.key.to_bytes());
+    println!();
+
+    let csr = polyproto::certs::idcsr::IdCsr::new(
+        &RdnSequence::from_str("CN=flori,DC=www,DC=polyphony,DC=chat,UID=flori@polyphony.chat,uniqueIdentifier=client1").unwrap(),
+        &priv_key,
+        &Capabilities::default_actor(),
+    )
+    .unwrap();
+
+    let data = csr.clone().to_der().unwrap();
+    let file_name_with_extension = "cert.csr";
+    #[cfg(not(target_arch = "wasm32"))]
+    std::fs::write(file_name_with_extension, &data).unwrap();
+
+    let cert = IdCert::from_actor_csr(
+        csr,
+        &priv_key,
+        Uint::new(&8932489u64.to_be_bytes()).unwrap(),
+        RdnSequence::from_str(
+            "CN=root,DC=www,DC=polyphony,DC=chat,UID=root@polyphony.chat,uniqueIdentifier=root",
+        )
+        .unwrap(),
+        Validity {
+            not_before: Time::UtcTime(
+                UtcTime::from_unix_duration(Duration::from_secs(10)).unwrap(),
+            ),
+            not_after: Time::UtcTime(
+                UtcTime::from_unix_duration(Duration::from_secs(1000)).unwrap(),
+            ),
+        },
+    )
+    .unwrap();
+    let data = cert.clone().to_der().unwrap();
+    let cert_from_der = IdCert::from_der(data).unwrap();
+    assert_eq!(cert_from_der, cert)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(test))]
+fn main() {}
+
+// As mentioned in the README, we start by implementing the signature trait.
+
+// Here, we start by defining the signature type, which is a wrapper around the signature type from
+// the ed25519-dalek crate.
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct Ed25519Signature {
+    signature: Ed25519DalekSignature,
+    algorithm: AlgorithmIdentifierOwned,
+}
+
+// We implement the Signature trait for our signature type.
+impl Signature for Ed25519Signature {
+    // We define the signature type from the ed25519-dalek crate as the associated type.
+    type Signature = Ed25519DalekSignature;
+
+    // This is straightforward: we return a reference to the signature.
+    fn as_signature(&self) -> &Self::Signature {
+        &self.signature
+    }
+
+    // The algorithm identifier for a given signature implementation is constant. We just need
+    // to define it here.
+    fn algorithm_identifier() -> AlgorithmIdentifierOwned {
+        AlgorithmIdentifierOwned {
+            // This is the OID for Ed25519. It is defined in the IANA registry.
+            oid: ObjectIdentifier::from_str("1.3.101.112").unwrap(),
+            // For this example, we don't need or want any parameters.
+            parameters: None,
+        }
+    }
+
+    fn from_bitstring(signature: &[u8]) -> Self {
+        let mut signature_vec = signature.to_vec();
+        signature_vec.resize(64, 0);
+        let signature_array: [u8; 64] = {
+            let mut array = [0; 64];
+            array.copy_from_slice(&signature_vec[..]);
+            array
+        };
+        Self {
+            signature: Ed25519DalekSignature::from_bytes(&signature_array),
+            algorithm: Self::algorithm_identifier(),
+        }
+    }
+}
+
+// The `SignatureBitStringEncoding` trait is used to convert a signature to a bit string. We implement
+// it for our signature type.
+impl SignatureBitStringEncoding for Ed25519Signature {
+    fn to_bitstring(&self) -> der::Result<der::asn1::BitString> {
+        BitString::from_bytes(&self.as_signature().to_bytes())
+    }
+}
+
+// Next, we implement the key traits. We start by defining the private key type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Ed25519PrivateKey {
+    // Defined below
+    public_key: Ed25519PublicKey,
+    // The private key from the ed25519-dalek crate
+    key: SigningKey,
+}
+
+impl PrivateKey<Ed25519Signature> for Ed25519PrivateKey {
+    type PublicKey = Ed25519PublicKey;
+
+    // Return a reference to the public key
+    fn pubkey(&self) -> &Self::PublicKey {
+        &self.public_key
+    }
+
+    // Signs a message. The beauty of having to wrap the ed25519-dalek crate is that we can
+    // harness all of its functionality, such as the `sign` method.
+    fn sign(&self, data: &[u8]) -> Ed25519Signature {
+        let signature = self.key.sign(data);
+        Ed25519Signature {
+            signature,
+            algorithm: self.algorithm_identifier(),
+        }
+    }
+}
+
+impl Ed25519PrivateKey {
+    // Let's also define a handy method to generate a key pair.
+    pub fn gen_keypair(csprng: &mut OsRng) -> Self {
+        let key = SigningKey::generate(csprng);
+        let public_key = Ed25519PublicKey {
+            key: key.verifying_key(),
+        };
+        Self { public_key, key }
+    }
+}
+
+// Same thing as above for the public key type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Ed25519PublicKey {
+    // The public key type from the ed25519-dalek crate
+    key: VerifyingKey,
+}
+
+impl PublicKey<Ed25519Signature> for Ed25519PublicKey {
+    // Verifies a signature. We use the `verify_strict` method from the ed25519-dalek crate.
+    // This method is used to mitigate weak key forgery.
+    fn verify_signature(
+        &self,
+        signature: &Ed25519Signature,
+        data: &[u8],
+    ) -> Result<(), polyproto::errors::composite::PublicKeyError> {
+        match self.key.verify_strict(data, signature.as_signature()) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(polyproto::errors::composite::PublicKeyError::BadSignature),
+        }
+    }
+
+    // Returns the public key info. Public key info is used to encode the public key in a
+    // certificate or a CSR. It is named after the `SubjectPublicKeyInfo` type from the X.509
+    // standard, and thus includes the information needed to encode the public key in a certificate
+    // or a CSR.
+    fn public_key_info(&self) -> PublicKeyInfo {
+        PublicKeyInfo {
+            algorithm: Ed25519Signature::algorithm_identifier(),
+            public_key_bitstring: BitString::from_bytes(&self.key.to_bytes()).unwrap(),
+        }
+    }
+
+    fn from_public_key_info(public_key_info: PublicKeyInfo) -> Self {
+        let mut key_vec = public_key_info.public_key_bitstring.raw_bytes().to_vec();
+        key_vec.resize(32, 0);
+        let signature_array: [u8; 32] = {
+            let mut array = [0; 32];
+            array.copy_from_slice(&key_vec[..]);
+            array
+        };
+        Self {
+            key: VerifyingKey::from_bytes(&signature_array).unwrap(),
+        }
+    }
+}

--- a/src/certs/capabilities/basic_constraints.rs
+++ b/src/certs/capabilities/basic_constraints.rs
@@ -242,8 +242,7 @@ mod test {
             ca: true,
             path_length: Some(0u64),
         };
-        let extension = Extension::try_from(basic_constraints).unwrap();
-        dbg!(extension);
+        let _extension = Extension::try_from(basic_constraints).unwrap();
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -324,7 +324,7 @@ mod test {
             KeyUsage::DigitalSignature,
         ];
         vec.sort();
-        assert!(*vec.get(0).unwrap() == KeyUsage::DigitalSignature);
+        assert!(*vec.first().unwrap() == KeyUsage::DigitalSignature);
         assert!(*vec.get(1).unwrap() == KeyUsage::ContentCommitment);
         assert!(*vec.get(2).unwrap() == KeyUsage::DataEncipherment);
         assert!(*vec.get(3).unwrap() == KeyUsage::EncipherOnly);

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -82,7 +82,7 @@ impl TryFrom<u32> for KeyUsage {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct KeyUsages {
     pub key_usages: Vec<KeyUsage>,
 }

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -5,7 +5,7 @@
 use std::str::FromStr;
 
 use der::asn1::{BitString, OctetString, SetOfVec};
-use der::{Any, Encode, Tag, Tagged};
+use der::{Any, Decode, Encode, Tag, Tagged};
 use spki::ObjectIdentifier;
 use x509_cert::attr::Attribute;
 use x509_cert::ext::Extension;
@@ -83,25 +83,133 @@ impl TryFrom<u32> for KeyUsage {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+/// The KeyUsages struct is a collection of KeyUsage variants.
 pub struct KeyUsages {
+    /// Vector of KeyUsage variants.
     pub key_usages: Vec<KeyUsage>,
 }
 
 impl KeyUsages {
+    /// Creates a new KeyUsages struct from a slice of KeyUsage variants.
     pub fn new(key_usages: &[KeyUsage]) -> Self {
         KeyUsages {
             key_usages: key_usages.to_vec(),
         }
     }
+
+    /// Converts a byte slice to a KeyUsages struct, given that the byte slice is a bitstring
+    /// representing the KeyUsages.
+    ///
+    /// RFC 5280 says:
+    /// ```text
+    /// KeyUsage ::= BIT STRING {
+    ///     digitalSignature        (0),
+    ///     nonRepudiation          (1), -- recent editions of X.509 have
+    ///                                  -- renamed this bit to contentCommitment
+    ///     keyEncipherment         (2),
+    ///     dataEncipherment        (3),
+    ///     keyAgreement            (4),
+    ///     keyCertSign             (5),
+    ///     cRLSign                 (6),
+    ///     encipherOnly            (7),
+    ///     decipherOnly            (8) }
+    /// ```
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, InvalidInput> {
+        /* Below, we are doing some operations on bits. RFC 5280 says:
+        KeyUsage ::= BIT STRING {
+            digitalSignature        (0),
+            nonRepudiation          (1), -- recent editions of X.509 have
+                                -- renamed this bit to contentCommitment
+            keyEncipherment         (2),
+            dataEncipherment        (3),
+            keyAgreement            (4),
+            keyCertSign             (5),
+            cRLSign                 (6),
+            encipherOnly            (7),
+            decipherOnly            (8) }
+
+        It is now our task to check, which bits (0 - 8) are set, and to construct KeyUsage variants
+        from this information.
+        Note, that BitStrings represent the bits they store in big endian order, meaning that the
+        most significant bit (MSB) is the first bit in the BitString.
+        */
+        let bitstring = BitString::from_bytes(bytes)?;
+        // The "starting number" is 2 to the power of len(bitstring) [<-pseudocode].
+        // For a bit of length 8, this would be 2^8=256.
+        let mut starting_number = 2u32.pow(bitstring.bit_len() as u32);
+        let mut key_usages = Vec::new();
+        // We iterate over all bits, check if the current bit is set and try to convert the
+        // current value of starting_number to a KeyUsage variant. On every iteration, we divide
+        // starting_number by two, until it equals 1 and thus cannot be divided any further.
+        for bit in bitstring.bits() {
+            match bit {
+                true => 1u8,
+                false => {
+                    divide_starting_number(&mut starting_number);
+                    continue;
+                }
+            };
+            key_usages.push(KeyUsage::try_from(starting_number)?);
+            if starting_number == 1 {
+                // Stop the loop if starting_number is already 1.
+                break;
+            }
+            divide_starting_number(&mut starting_number);
+        }
+        Ok(KeyUsages::new(&key_usages))
+    }
+
+    /// Converts the KeyUsages to a bitstring in little endian order.
+    pub fn to_le_bits(mut self) -> [bool; 9] {
+        self.key_usages.sort();
+        self.key_usages.dedup();
+        let mut bit_vec = [false; 9];
+        for item in self.key_usages.into_iter() {
+            match item {
+                KeyUsage::DigitalSignature => bit_vec[0] = true,
+                KeyUsage::ContentCommitment => bit_vec[1] = true,
+                KeyUsage::KeyEncipherment => bit_vec[2] = true,
+                KeyUsage::DataEncipherment => bit_vec[3] = true,
+                KeyUsage::KeyAgreement => bit_vec[4] = true,
+                KeyUsage::KeyCertSign => bit_vec[5] = true,
+                KeyUsage::CrlSign => bit_vec[6] = true,
+                KeyUsage::EncipherOnly => bit_vec[7] = true,
+                KeyUsage::DecipherOnly => bit_vec[8] = true,
+            }
+        }
+        bit_vec
+    }
+
+    /// Converts the KeyUsages to a bitstring in big endian order.
+    pub fn to_be_bits(self) -> [bool; 9] {
+        let mut bit_vec = self.to_le_bits();
+        bit_vec.reverse();
+        bit_vec
+    }
+
+    /// Converts the KeyUsages to a [BitString].
+    pub fn to_bitstring(self) -> BitString {
+        let bits = self.to_be_bits();
+        let mut bytes = bits
+            .iter()
+            .map(|x| if *x { 1 } else { 0 })
+            .collect::<Vec<u8>>();
+        while bytes[0] == 0 {
+            bytes.remove(0);
+        }
+        let mut unused_bits: u8 = 0;
+        while bytes.len() % 8 != 0 {
+            bytes.push(0);
+            unused_bits += 1;
+        }
+        BitString::new(unused_bits, bytes)
+            .expect("Error when converting KeyUsages to BitString. Please report this error")
+    }
 }
 
 impl From<KeyUsages> for BitString {
     fn from(value: KeyUsages) -> Self {
-        let mut number: usize = 0;
-        for item in value.key_usages.iter() {
-            number += *item as usize;
-        }
-        BitString::from_bytes(number.to_be_bytes().as_slice()).expect("Error when trying to convert KeyUsages to BitString. Please report this error to https://github.com/polyphony-chat/polyproto")
+        value.to_bitstring()
     }
 }
 
@@ -129,48 +237,7 @@ impl TryFrom<Attribute> for KeyUsages {
             }
         };
         let inner_value = value.values.get(0).expect("Illegal state. Please report this error to https://github.com/polyphony-chat/polyproto");
-        /* Below, we are doing some operations on bits. RFC 5280 says:
-        KeyUsage ::= BIT STRING {
-            digitalSignature        (0),
-            nonRepudiation          (1), -- recent editions of X.509 have
-                                -- renamed this bit to contentCommitment
-            keyEncipherment         (2),
-            dataEncipherment        (3),
-            keyAgreement            (4),
-            keyCertSign             (5),
-            cRLSign                 (6),
-            encipherOnly            (7),
-            decipherOnly            (8) }
-
-        It is now our task to check, which bits (0 - 8) are set, and to construct KeyUsage variants
-        from this information.
-        Note, that BitStrings represent the bits they store in big endian order, meaning that the
-        most significant bit (MSB) is the first bit in the BitString.
-        */
-        let bitstring = BitString::from_bytes(inner_value.value())?;
-        // The "starting number" is 2 to the power of len(bitstring) [<-pseudocode].
-        // For a bit of length 8, this would be 2^8=256.
-        let mut starting_number = 2u32.pow(bitstring.bit_len() as u32);
-        let mut key_usages = Vec::new();
-        // We iterate over all bits, check if the current bit is set and try to convert the
-        // current value of starting_number to a KeyUsage variant. On every iteration, we divide
-        // starting_number by two, until it equals 1 and thus cannot be divided any further.
-        for bit in bitstring.bits() {
-            match bit {
-                true => 1u8,
-                false => {
-                    divide_starting_number(&mut starting_number);
-                    continue;
-                }
-            };
-            key_usages.push(KeyUsage::try_from(starting_number)?);
-            if starting_number == 1 {
-                // Stop the loop if starting_number is already 1.
-                break;
-            }
-            divide_starting_number(&mut starting_number);
-        }
-        Ok(KeyUsages::new(&key_usages))
+        KeyUsages::from_bytes(inner_value.value())
     }
 }
 
@@ -184,19 +251,47 @@ impl TryFrom<Extension> for KeyUsages {
     type Error = InvalidInput;
 
     fn try_from(value: Extension) -> Result<Self, Self::Error> {
-        todo!()
+        if value.extn_id.to_string().as_str() != OID_KEY_USAGE {
+            return Err(InvalidInput::IncompatibleVariantForConversion {
+                reason: format!(
+                    "Expected OID {} for KeyUsages, found OID {}",
+                    OID_KEY_USAGE, value.extn_id
+                ),
+            });
+        }
+        // here we need to NOT just do .as_bytes() but to somehow get the actual value in this
+        // octetstring
+        // TODO
+        KeyUsages::from_bytes(value.extn_value.as_bytes())
     }
 }
 
 impl From<KeyUsages> for Attribute {
     fn from(value: KeyUsages) -> Self {
-        todo!()
+        let mut sov = SetOfVec::new();
+        let bitstring = value.to_bitstring();
+        sov.insert(
+            Any::from_der(&bitstring.to_der().expect(
+                "Error occurred when converting blah blah blah this will be tryfrom anyways soon",
+            ))
+            .expect("this is tryfrom soon lalalalalla"),
+        )
+        .expect("wow");
+        dbg!(&sov);
+        Attribute {
+            oid: ObjectIdentifier::from_str(OID_KEY_USAGE).expect(
+                "Error occurred when converting KeyUsages to ObjectIdentifier. Please report this crash",
+            ),
+            values: sov,
+        }
     }
 }
 
 impl From<KeyUsages> for Extension {
     fn from(value: KeyUsages) -> Self {
-        todo!()
+        let bitstring = value.to_bitstring();
+        let any = Any::from_der(&bitstring.to_der().expect("guh")).expect("Error occurred when converting KeyUsages to BitString. Please report this crash at https://github.com/polyphony-chat/polyproto");
+        Extension { extn_id: ObjectIdentifier::from_str(OID_KEY_USAGE).expect("Error occurred when converting KeyUsages to ObjectIdentifier. Please report this crash at https://github.com/polyphony-chat/polyproto"), critical: true, extn_value: OctetString::new(any.to_der().expect("Error occurred when converting KeyUsages to DER. Please report this crash at https://github.com/polyphony-chat/polyproto")).expect("Error occurred when creating OctetString. Please report this crash at https://github.com/polyphony-chat/polyproto") }
     }
 }
 
@@ -213,6 +308,23 @@ mod test {
             KeyUsage::KeyAgreement,
         ]);
         let bitstring = BitString::from(key_usages);
-        dbg!(bitstring)
+        dbg!(bitstring);
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn key_usages_vec_sorts_correctly() {
+        #[allow(clippy::useless_vec)]
+        let mut vec = vec![
+            KeyUsage::ContentCommitment,
+            KeyUsage::EncipherOnly,
+            KeyUsage::DataEncipherment,
+            KeyUsage::DigitalSignature,
+        ];
+        vec.sort();
+        assert!(*vec.get(0).unwrap() == KeyUsage::DigitalSignature);
+        assert!(*vec.get(1).unwrap() == KeyUsage::ContentCommitment);
+        assert!(*vec.get(2).unwrap() == KeyUsage::DataEncipherment);
+        assert!(*vec.get(3).unwrap() == KeyUsage::EncipherOnly);
     }
 }

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -79,6 +79,34 @@ impl From<KeyUsages> for BitString {
     }
 }
 
+impl TryFrom<Attribute> for KeyUsages {
+    type Error = InvalidInput;
+
+    fn try_from(value: Attribute) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<Extension> for KeyUsages {
+    type Error = InvalidInput;
+
+    fn try_from(value: Extension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl From<KeyUsages> for Attribute {
+    fn from(value: KeyUsages) -> Self {
+        todo!()
+    }
+}
+
+impl From<KeyUsages> for Extension {
+    fn from(value: KeyUsages) -> Self {
+        todo!()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -4,7 +4,7 @@
 
 use std::str::FromStr;
 
-use der::asn1::{OctetString, SetOfVec};
+use der::asn1::{BitString, OctetString, SetOfVec};
 use der::{Any, Encode, Tag, Tagged};
 use spki::ObjectIdentifier;
 use x509_cert::attr::Attribute;
@@ -19,247 +19,63 @@ use super::*;
 /// restriction might be employed when a key that could be used for more than one operation is to
 /// be restricted. See <https://cryptography.io/en/latest/x509/reference/#cryptography.x509.KeyUsage>
 pub enum KeyUsage {
-    /// This purpose is set to true when the subject public key is used for verifying digital
+    /// This purpose is set when the subject public key is used for verifying digital
     /// signatures, other than signatures on certificates (`key_cert_sign`) and CRLs (`crl_sign`).
-    DigitalSignature(bool),
-    /// This purpose is set to true when the subject public key is used for verifying signatures on
-    /// certificate revocation lists.
-    CrlSign(bool),
-    /// This purpose is set to true when the subject public key is used for verifying digital
+    DigitalSignature = 1,
+    /// This purpose is set when the subject public key is used for verifying digital
     /// signatures, other than signatures on certificates (`key_cert_sign`) and CRLs (`crl_sign`).
     /// It is used to provide a non-repudiation service that protects against the signing entity
     /// falsely denying some action. In the case of later conflict, a reliable third party may
     /// determine the authenticity of the signed data. This was called `non_repudiation` in older
     /// revisions of the X.509 specification.
-    ContentCommitment(bool),
-    /// This purpose is set to true when the subject public key is used for enciphering private or
+    ContentCommitment = 2,
+    /// This purpose is set when the subject public key is used for enciphering private or
     /// secret keys.
-    KeyEncipherment(bool),
-    /// This purpose is set to true when the subject public key is used for directly enciphering raw
+    KeyEncipherment = 4,
+    /// This purpose is set when the subject public key is used for directly enciphering raw
     /// user data without the use of an intermediate symmetric cipher.
-    DataEncipherment(bool),
-    /// This purpose is set to true when the subject public key is used for key agreement. For
+    DataEncipherment = 8,
+    /// This purpose is set when the subject public key is used for key agreement. For
     /// example, when a Diffie-Hellman key is to be used for key management, then this purpose is
-    /// set to true.
-    KeyAgreement(bool),
-    /// This purpose is set to true when the subject public key is used for verifying signatures on
+    /// set.
+    KeyAgreement = 16,
+    /// This purpose is set when the subject public key is used for verifying signatures on
     /// public key certificates. If this purpose is set to true then ca must be true in the
     /// `BasicConstraints` extension.
-    KeyCertSign(bool),
-    /// When this purposes is set to true and the `key_agreement` purpose is also set, the subject
+    KeyCertSign = 32,
+    /// This purpose is set when the subject public key is used for verifying signatures on
+    /// certificate revocation lists.
+    CrlSign = 64,
+    /// When this purpose is set and the `key_agreement` purpose is also set, the subject
     /// public key may be used only for enciphering data while performing key agreement. The
-    /// `KeyAgreement` capability must be set to `true` for this.
-    EncipherOnly(bool),
-    /// When this purposes is set to true and the `key_agreement` purpose is also set, the subject
+    /// `KeyAgreement` capability must be set for this.
+    EncipherOnly = 128,
+    /// When this purpose is set and the `key_agreement` purpose is also set, the subject
     /// public key may be used only for deciphering data while performing key agreement. The
-    /// `KeyAgreement` capability must be set to `true` for this.
-    DecipherOnly(bool),
+    /// `KeyAgreement` capability must be set for this.
+    DecipherOnly = 256,
 }
 
-impl From<KeyUsage> for bool {
-    fn from(value: KeyUsage) -> Self {
-        match value {
-            KeyUsage::DigitalSignature(val) => val,
-            KeyUsage::CrlSign(val) => val,
-            KeyUsage::ContentCommitment(val) => val,
-            KeyUsage::KeyEncipherment(val) => val,
-            KeyUsage::DataEncipherment(val) => val,
-            KeyUsage::KeyAgreement(val) => val,
-            KeyUsage::KeyCertSign(val) => val,
-            KeyUsage::EncipherOnly(val) => val,
-            KeyUsage::DecipherOnly(val) => val,
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KeyUsages {
+    pub key_usages: Vec<KeyUsage>,
+}
+
+impl KeyUsages {
+    pub fn new(key_usages: &[KeyUsage]) -> Self {
+        KeyUsages {
+            key_usages: key_usages.to_vec(),
         }
     }
 }
 
-impl TryFrom<Attribute> for KeyUsage {
-    type Error = InvalidInput;
-
-    /// Performs the conversion.
-    ///
-    /// Fails, if the input attribute does not contain exactly one value, or if the input attribute
-    /// does not contain a boolean value. Also fails if the OID of the attribute does not match any
-    /// known KeyUsage variant.
-    fn try_from(value: Attribute) -> Result<Self, Self::Error> {
-        // PRETTYFYME: I know this is a bit of a mess, but it works. If anyone wants to make it
-        // prettier, feel free to do so.
-
-        // Check if the attribute contains exactly one value
-        if value.values.len() != 1usize {
-            return Err(InvalidInput::IncompatibleVariantForConversion { reason: "This attribute does not store exactly one value, as would be expected for a KeyUsage attribute".to_string() });
+impl From<KeyUsages> for BitString {
+    fn from(value: KeyUsages) -> Self {
+        let mut number: usize = 0;
+        for item in value.key_usages.iter() {
+            number += *item as usize;
         }
-        let sov = value.values.get(0);
-
-        // The first value inside the Attribute is a SetOfVec. We need to look inside the SetOfVec to
-        // find the actual attribute we are interested in.
-        if let Some(inner_value) = sov {
-            if inner_value.tag() != Tag::Boolean {
-                return Err(InvalidInput::IncompatibleVariantForConversion { reason: format!("Only Any objects with boolean tags can be converted to a KeyUsage enum variant. Expected Tag::Boolean, found {:?}", inner_value.tag()) });
-            }
-            // This is how booleans are apparently encoded in ASN.1
-            let boolean_value = match inner_value.value() {
-                &[0x00] => false,
-                &[0xFF] | &[0x01] => true,
-                _ => {
-                    return Err(InvalidInput::IncompatibleVariantForConversion {
-                        reason: "Encountered unexpected value for Boolean tag".to_string(),
-                    });
-                }
-            };
-            // Now we have to match the OID of the attribute to the known KeyUsage variants
-            return Ok(match value.oid.to_string().as_str() {
-                super::OID_KEY_USAGE_CONTENT_COMMITMENT => KeyUsage::ContentCommitment(boolean_value),
-                super::OID_KEY_USAGE_CRL_SIGN => KeyUsage::CrlSign(boolean_value),
-                super::OID_KEY_USAGE_DATA_ENCIPHERMENT => KeyUsage::DataEncipherment(boolean_value),
-                super::OID_KEY_USAGE_DECIPHER_ONLY => KeyUsage::DecipherOnly(boolean_value),
-                super::OID_KEY_USAGE_DIGITAL_SIGNATURE => KeyUsage::DigitalSignature(boolean_value),
-                super::OID_KEY_USAGE_ENCIPHER_ONLY => KeyUsage::EncipherOnly(boolean_value),
-                super::OID_KEY_USAGE_KEY_AGREEMENT => KeyUsage::KeyAgreement(boolean_value),
-                #[allow(unreachable_patterns)] // cargo thinks the below pattern is unreachable.
-                super::OID_KEY_USAGE_KEY_CERT_SIGN => KeyUsage::KeyCertSign(boolean_value),
-                super::OID_KEY_USAGE_KEY_ENCIPHERMENT => KeyUsage::KeyEncipherment(boolean_value),
-                // If the OID does not match any known KeyUsage variant, we return an error
-                _ => {
-                    return Err(InvalidInput::IncompatibleVariantForConversion {
-                            reason: format!("The OID of the attribute does not match any known KeyUsage variant. Found OID \"{}\"", value.oid)
-                        },
-                    )
-                }
-            });
-        }
-        // If the attribute does not contain a value, we return an error
-        Err(InvalidInput::IncompatibleVariantForConversion {
-            reason: "The attribute does not contain a value".to_string(),
-        })
-    }
-}
-
-impl TryFrom<Extension> for KeyUsage {
-    type Error = InvalidInput;
-
-    /// Performs the conversion.
-    ///
-    /// Fails, if the input attribute does not contain a boolean value. Also fails if the OID of
-    /// the attribute does not match any known KeyUsage variant, especially when the unknown OID is
-    /// marked as "critical"
-    fn try_from(value: Extension) -> Result<Self, Self::Error> {
-        #[allow(unreachable_patterns)]
-        if value.critical
-            && !matches!(
-                value.extn_id.to_string().as_str(),
-                OID_KEY_USAGE_CONTENT_COMMITMENT
-                    | OID_KEY_USAGE_CRL_SIGN
-                    | OID_KEY_USAGE_DATA_ENCIPHERMENT
-                    | OID_KEY_USAGE_DATA_ENCIPHERMENT
-                    | OID_KEY_USAGE_DECIPHER_ONLY
-                    | OID_KEY_USAGE_DIGITAL_SIGNATURE
-                    | OID_KEY_USAGE_ENCIPHER_ONLY
-                    | OID_KEY_USAGE_KEY_AGREEMENT
-                    | OID_KEY_USAGE_KEY_CERT_SIGN
-                    | OID_KEY_USAGE_KEY_ENCIPHERMENT
-            )
-        {
-            // Error if we encounter a "critical" X.509 extension which we do not know of
-            return Err(InvalidInput::UnknownCriticalExtension { oid: value.extn_id });
-        }
-
-        let boolean_value = match value.extn_value.as_bytes() {
-            &[0x00] => false,
-            &[0xFF] | &[0x01] => true,
-            _ => {
-                return Err(InvalidInput::IncompatibleVariantForConversion {
-                    reason: "Encountered unexpected value for Boolean tag".to_string(),
-                });
-            }
-        };
-        // Now we have to match the OID of the attribute to the known KeyUsage variants
-        #[allow(unreachable_patterns)]
-        return Ok(match value.extn_id.to_string().as_str() {
-            super::OID_KEY_USAGE_CONTENT_COMMITMENT => KeyUsage::ContentCommitment(boolean_value),
-            super::OID_KEY_USAGE_CRL_SIGN => KeyUsage::CrlSign(boolean_value),
-            super::OID_KEY_USAGE_DATA_ENCIPHERMENT => KeyUsage::DataEncipherment(boolean_value),
-            super::OID_KEY_USAGE_DECIPHER_ONLY => KeyUsage::DecipherOnly(boolean_value),
-            super::OID_KEY_USAGE_DIGITAL_SIGNATURE => KeyUsage::DigitalSignature(boolean_value),
-            super::OID_KEY_USAGE_ENCIPHER_ONLY => KeyUsage::EncipherOnly(boolean_value),
-            super::OID_KEY_USAGE_KEY_AGREEMENT => KeyUsage::KeyAgreement(boolean_value),
-            super::OID_KEY_USAGE_KEY_CERT_SIGN => KeyUsage::KeyCertSign(boolean_value),
-            super::OID_KEY_USAGE_KEY_ENCIPHERMENT => KeyUsage::KeyEncipherment(boolean_value),
-            // If the OID does not match any known KeyUsage variant, we return an error
-            _ => {
-                return Err(InvalidInput::IncompatibleVariantForConversion {
-                        reason: format!("The OID of the attribute does not match any known KeyUsage variant. Found OID \"{}\"", value.extn_id)
-                    },
-                )
-            }
-        });
-    }
-}
-
-impl From<KeyUsage> for Any {
-    fn from(value: KeyUsage) -> Self {
-        Any::new(der::Tag::Boolean,match bool::from(value) {
-            true => vec![0xff],
-            false => vec![0x00],
-        },
-        ).expect("Error occurred when converting BasicConstraints bool to der::Any. Please report this crash at https://github.com/polyphony-chat/polyproto.")
-    }
-}
-
-impl From<KeyUsage> for ObjectIdentifier {
-    fn from(value: KeyUsage) -> Self {
-        let result = match value {
-            KeyUsage::DigitalSignature(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_DIGITAL_SIGNATURE)
-            }
-            KeyUsage::CrlSign(_) => ObjectIdentifier::from_str(super::OID_KEY_USAGE_CRL_SIGN),
-            KeyUsage::ContentCommitment(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_CONTENT_COMMITMENT)
-            }
-            KeyUsage::KeyEncipherment(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_KEY_ENCIPHERMENT)
-            }
-            KeyUsage::DataEncipherment(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_DATA_ENCIPHERMENT)
-            }
-            KeyUsage::KeyAgreement(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_KEY_AGREEMENT)
-            }
-            KeyUsage::KeyCertSign(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_KEY_CERT_SIGN)
-            }
-            KeyUsage::EncipherOnly(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_ENCIPHER_ONLY)
-            }
-            KeyUsage::DecipherOnly(_) => {
-                ObjectIdentifier::from_str(super::OID_KEY_USAGE_DECIPHER_ONLY)
-            }
-        };
-        result.expect("Error occurred when converting KeyUsage enum to ObjectIdentifier. Please report this crash at https://github.com/polyphony-chat/polyproto.")
-    }
-}
-
-impl From<KeyUsage> for Attribute {
-    fn from(value: KeyUsage) -> Self {
-        // Creating a Any from a bool is really simple, so we can expect this to never fail.
-        let any_val = Any::from(value);
-        let mut sov = SetOfVec::new();
-        // .insert() only fails if the value is not unique. We are inserting a single value, so this
-        // should never fail. See tests below for verification.
-        sov.insert(any_val).expect("Error occurred when inserting KeyUsage into der::Any to SetOfVec. Please report this crash at https://github.com/polyphony-chat/polyproto");
-        Attribute {
-            oid: value.into(),
-            values: sov,
-        }
-    }
-}
-
-impl From<KeyUsage> for Extension {
-    fn from(value: KeyUsage) -> Self {
-        Extension {
-            extn_id: value.into(),
-            critical: true,
-            extn_value: OctetString::new(bool::from(value).to_der().expect("Error occured when trying to convert bool to DER. Please report this crash at https://github.com/polyphony-chat/polyproto")).expect("Error occured when trying to convert bool to an OctetString. Please report this crash at https://github.com/polyphony-chat/polyproto"),
-        }
+        BitString::from_bytes(number.to_be_bytes().as_slice()).expect("Error when trying to convert KeyUsages to BitString. Please report this error to https://github.com/polyphony-chat/polyproto")
     }
 }
 
@@ -269,9 +85,13 @@ mod test {
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn key_usage_to_extension() {
-        let key_usage = KeyUsage::KeyCertSign(true);
-        let extension = Extension::from(key_usage);
-        dbg!(extension);
+    fn key_usages_to_bitstring() {
+        let key_usages = KeyUsages::new(&[
+            KeyUsage::CrlSign,
+            KeyUsage::EncipherOnly,
+            KeyUsage::KeyAgreement,
+        ]);
+        let bitstring = BitString::from(key_usages);
+        dbg!(bitstring)
     }
 }

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -83,7 +83,26 @@ impl TryFrom<Attribute> for KeyUsages {
     type Error = InvalidInput;
 
     fn try_from(value: Attribute) -> Result<Self, Self::Error> {
-        todo!()
+        if value.tag() != Tag::BitString {
+            return Err(InvalidInput::IncompatibleVariantForConversion {
+                reason: format!("Expected BitString, found {}", value.tag()),
+            });
+        }
+        match value.values.len() {
+            0 => return Ok(KeyUsages::new(&[])),
+            1 => (),
+            _ => {
+                return Err(InvalidInput::ConstraintError(
+                    ConstraintError::OutOfBounds {
+                        lower: 0,
+                        upper: 1,
+                        actual: value.values.len().to_string(),
+                        reason: Some("Too many values to be a valid KeyUsages value".to_string()),
+                    },
+                ))
+            }
+        };
+        let inner_value = value.values.get(0).expect("Illegal state. Please report this error to https://github.com/polyphony-chat/polyproto");
     }
 }
 

--- a/src/certs/capabilities/key_usage.rs
+++ b/src/certs/capabilities/key_usage.rs
@@ -156,14 +156,14 @@ impl TryFrom<Attribute> for KeyUsages {
         // current value of starting_number to a KeyUsage variant. On every iteration, we divide
         // starting_number by two, until it equals 1 and thus cannot be divided any further.
         for bit in bitstring.bits() {
-            let bitval = match bit {
+            match bit {
                 true => 1u8,
                 false => {
                     divide_starting_number(&mut starting_number);
                     continue;
                 }
             };
-            key_usages.push(KeyUsage::try_from(starting_number as u32)?);
+            key_usages.push(KeyUsage::try_from(starting_number)?);
             if starting_number == 1 {
                 // Stop the loop if starting_number is already 1.
                 break;

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -50,7 +50,7 @@ pub const OID_KEY_USAGE: &str = "2.5.29.15";
 /// are relevant to polyproto certificates.
 pub struct Capabilities {
     /// The key usage extension defines the purpose of the key contained in the certificate.
-    pub key_usage: Vec<KeyUsage>,
+    pub key_usage: Vec<KeyUsages>,
     /// Extension type that defines whether a given certificate is allowed
     /// to sign additional certificates and what path length restrictions may exist.
     pub basic_constraints: BasicConstraints,
@@ -107,7 +107,7 @@ impl TryFrom<Attributes> for Capabilities {
     /// to ensure that the constraints are valid according to the X.509 standard and the polyproto
     /// specification.
     fn try_from(value: Attributes) -> Result<Self, Self::Error> {
-        let mut key_usages: Vec<KeyUsage> = Vec::new();
+        let mut key_usages: Vec<KeyUsages> = Vec::new();
         let mut basic_constraints = BasicConstraints::default();
         let mut num_basic_constraints = 0u8;
         for item in value.iter() {
@@ -122,7 +122,7 @@ impl TryFrom<Attributes> for Capabilities {
                 | OID_KEY_USAGE_KEY_AGREEMENT
                 | OID_KEY_USAGE_KEY_CERT_SIGN
                 | OID_KEY_USAGE_KEY_ENCIPHERMENT => {
-                    key_usages.push(KeyUsage::try_from(item.clone())?);
+                    key_usages.push(KeyUsages::try_from(item.clone())?);
                 }
                 OID_BASIC_CONSTRAINTS => {
                     num_basic_constraints += 1;
@@ -189,7 +189,7 @@ impl TryFrom<Extensions> for Capabilities {
     /// these resulting [Capabilities].
     fn try_from(value: Extensions) -> Result<Self, Self::Error> {
         let mut basic_constraints: BasicConstraints = BasicConstraints::default();
-        let mut key_usage: Vec<KeyUsage> = Vec::new();
+        let mut key_usage: Vec<KeyUsages> = Vec::new();
         for item in value.iter() {
             #[allow(unreachable_patterns)] // cargo thinks that we have an unreachable pattern here
             match item.extn_id.to_string().as_str() {
@@ -205,7 +205,7 @@ impl TryFrom<Extensions> for Capabilities {
                 | OID_KEY_USAGE_KEY_AGREEMENT
                 | OID_KEY_USAGE_KEY_CERT_SIGN
                 | OID_KEY_USAGE_KEY_ENCIPHERMENT => {
-                    key_usage.push(KeyUsage::try_from(item.clone())?)
+                    key_usage.push(KeyUsages::try_from(item.clone())?)
                 },
                 _ => return Err(InvalidInput::ConstraintError(ConstraintError::Malformed(Some(format!("Invalid OID found for converting this set of Extensions to Capabilities: {} is not a valid OID for BasicConstraints or KeyUsages", item.extn_id)))))
             };
@@ -225,27 +225,27 @@ mod test {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_key_usage_to_object_identifier() {
-        let _ = ObjectIdentifier::from(KeyUsage::DigitalSignature(true));
-        let _ = ObjectIdentifier::from(KeyUsage::CrlSign(true));
-        let _ = ObjectIdentifier::from(KeyUsage::ContentCommitment(true));
-        let _ = ObjectIdentifier::from(KeyUsage::KeyEncipherment(true));
-        let _ = ObjectIdentifier::from(KeyUsage::DataEncipherment(true));
-        let _ = ObjectIdentifier::from(KeyUsage::KeyAgreement(true));
-        let _ = ObjectIdentifier::from(KeyUsage::KeyCertSign(true));
-        let _ = ObjectIdentifier::from(KeyUsage::EncipherOnly(true));
-        let _ = ObjectIdentifier::from(KeyUsage::DecipherOnly(true));
+        let _ = ObjectIdentifier::from(KeyUsages::DigitalSignature(true));
+        let _ = ObjectIdentifier::from(KeyUsages::CrlSign(true));
+        let _ = ObjectIdentifier::from(KeyUsages::ContentCommitment(true));
+        let _ = ObjectIdentifier::from(KeyUsages::KeyEncipherment(true));
+        let _ = ObjectIdentifier::from(KeyUsages::DataEncipherment(true));
+        let _ = ObjectIdentifier::from(KeyUsages::KeyAgreement(true));
+        let _ = ObjectIdentifier::from(KeyUsages::KeyCertSign(true));
+        let _ = ObjectIdentifier::from(KeyUsages::EncipherOnly(true));
+        let _ = ObjectIdentifier::from(KeyUsages::DecipherOnly(true));
     }
 
     fn test_key_usage_to_attribute(val: bool) {
-        let _ = Attribute::from(KeyUsage::DigitalSignature(val));
-        let _ = Attribute::from(KeyUsage::CrlSign(val));
-        let _ = Attribute::from(KeyUsage::ContentCommitment(val));
-        let _ = Attribute::from(KeyUsage::KeyEncipherment(val));
-        let _ = Attribute::from(KeyUsage::DataEncipherment(val));
-        let _ = Attribute::from(KeyUsage::KeyAgreement(val));
-        let _ = Attribute::from(KeyUsage::KeyCertSign(val));
-        let _ = Attribute::from(KeyUsage::EncipherOnly(val));
-        let _ = Attribute::from(KeyUsage::DecipherOnly(val));
+        let _ = Attribute::from(KeyUsages::DigitalSignature(val));
+        let _ = Attribute::from(KeyUsages::CrlSign(val));
+        let _ = Attribute::from(KeyUsages::ContentCommitment(val));
+        let _ = Attribute::from(KeyUsages::KeyEncipherment(val));
+        let _ = Attribute::from(KeyUsages::DataEncipherment(val));
+        let _ = Attribute::from(KeyUsages::KeyAgreement(val));
+        let _ = Attribute::from(KeyUsages::KeyCertSign(val));
+        let _ = Attribute::from(KeyUsages::EncipherOnly(val));
+        let _ = Attribute::from(KeyUsages::DecipherOnly(val));
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -312,9 +312,9 @@ mod test_key_usage_from_attribute {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_key_usage_from_attribute() {
-        let key_usage = KeyUsage::ContentCommitment(true);
+        let key_usage = KeyUsages::ContentCommitment(true);
         let attribute = Attribute::from(key_usage);
-        let result = KeyUsage::try_from(attribute);
+        let result = KeyUsages::try_from(attribute);
         dbg!(&result);
         assert!(result.is_ok());
     }
@@ -322,13 +322,13 @@ mod test_key_usage_from_attribute {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_key_usage_wrong_value_amount() {
-        let key_usage = KeyUsage::ContentCommitment(true);
+        let key_usage = KeyUsages::ContentCommitment(true);
         let mut attribute = Attribute::from(key_usage);
         attribute
             .values
-            .insert(Any::from(KeyUsage::DataEncipherment(false)))
+            .insert(Any::from(KeyUsages::DataEncipherment(false)))
             .unwrap();
-        let result = KeyUsage::try_from(attribute);
+        let result = KeyUsages::try_from(attribute);
         dbg!(&result);
         assert!(result.is_err());
     }
@@ -343,7 +343,7 @@ mod test_key_usage_from_attribute {
             oid: ObjectIdentifier::from_str(OID_KEY_USAGE_CONTENT_COMMITMENT).unwrap(),
             values: sov,
         };
-        let result = KeyUsage::try_from(attribute);
+        let result = KeyUsages::try_from(attribute);
         dbg!(&result);
         assert!(result.is_err());
     }
@@ -358,7 +358,7 @@ mod test_key_usage_from_attribute {
             oid: ObjectIdentifier::from_str("1.2.4.2.1.1.1.1.1.1.1.1.1.1.161.69").unwrap(),
             values: sov,
         };
-        let result = KeyUsage::try_from(attribute);
+        let result = KeyUsages::try_from(attribute);
         dbg!(&result);
         assert!(result.is_err());
     }
@@ -373,7 +373,7 @@ mod test_key_usage_from_attribute {
             oid: ObjectIdentifier::from_str(OID_KEY_USAGE_CONTENT_COMMITMENT).unwrap(),
             values: sov,
         };
-        let result = KeyUsage::try_from(attribute);
+        let result = KeyUsages::try_from(attribute);
         dbg!(&result);
         assert!(result.is_err());
     }

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -214,7 +214,7 @@ mod test {
         todo!()
     }
 
-    fn test_key_usage_to_attribute(val: bool) {
+    fn test_key_usage_to_attribute(_val: bool) {
         // TODO
         todo!()
     }

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -185,6 +185,7 @@ impl TryFrom<Extensions> for Capabilities {
                     basic_constraints = BasicConstraints::try_from(item.clone())?
                 }
                 OID_KEY_USAGE => {
+                    dbg!("KeyUsage to Capabilities");
                     key_usage = KeyUsages::try_from(item.clone())?
                 },
                 _ => return Err(InvalidInput::ConstraintError(ConstraintError::Malformed(Some(format!("Invalid OID found for converting this set of Extensions to Capabilities: {} is not a valid OID for BasicConstraints or KeyUsages", item.extn_id)))))
@@ -205,27 +206,13 @@ mod test {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_key_usage_to_object_identifier() {
-        let _ = ObjectIdentifier::from(KeyUsages::DigitalSignature(true));
-        let _ = ObjectIdentifier::from(KeyUsages::CrlSign(true));
-        let _ = ObjectIdentifier::from(KeyUsages::ContentCommitment(true));
-        let _ = ObjectIdentifier::from(KeyUsages::KeyEncipherment(true));
-        let _ = ObjectIdentifier::from(KeyUsages::DataEncipherment(true));
-        let _ = ObjectIdentifier::from(KeyUsages::KeyAgreement(true));
-        let _ = ObjectIdentifier::from(KeyUsages::KeyCertSign(true));
-        let _ = ObjectIdentifier::from(KeyUsages::EncipherOnly(true));
-        let _ = ObjectIdentifier::from(KeyUsages::DecipherOnly(true));
+        // TODO
+        todo!()
     }
 
     fn test_key_usage_to_attribute(val: bool) {
-        let _ = Attribute::from(KeyUsages::DigitalSignature(val));
-        let _ = Attribute::from(KeyUsages::CrlSign(val));
-        let _ = Attribute::from(KeyUsages::ContentCommitment(val));
-        let _ = Attribute::from(KeyUsages::KeyEncipherment(val));
-        let _ = Attribute::from(KeyUsages::DataEncipherment(val));
-        let _ = Attribute::from(KeyUsages::KeyAgreement(val));
-        let _ = Attribute::from(KeyUsages::KeyCertSign(val));
-        let _ = Attribute::from(KeyUsages::EncipherOnly(val));
-        let _ = Attribute::from(KeyUsages::DecipherOnly(val));
+        // TODO
+        todo!()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -292,25 +279,8 @@ mod test_key_usage_from_attribute {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_key_usage_from_attribute() {
-        let key_usage = KeyUsages::ContentCommitment(true);
-        let attribute = Attribute::from(key_usage);
-        let result = KeyUsages::try_from(attribute);
-        dbg!(&result);
-        assert!(result.is_ok());
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn test_key_usage_wrong_value_amount() {
-        let key_usage = KeyUsages::ContentCommitment(true);
-        let mut attribute = Attribute::from(key_usage);
-        attribute
-            .values
-            .insert(Any::from(KeyUsages::DataEncipherment(false)))
-            .unwrap();
-        let result = KeyUsages::try_from(attribute);
-        dbg!(&result);
-        assert!(result.is_err());
+        // TODO
+        todo!()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -187,7 +187,6 @@ impl TryFrom<Extensions> for Capabilities {
                     basic_constraints = BasicConstraints::try_from(item.clone())?
                 }
                 OID_KEY_USAGE => {
-                    dbg!("KeyUsage to Capabilities");
                     key_usage = KeyUsages::try_from(item.clone())?
                 },
                 _ => return Err(ConversionError::InvalidInput(InvalidInput::Malformed(format!("Invalid OID found for converting this set of Extensions to Capabilities: {} is not a valid OID for BasicConstraints or KeyUsages", item.extn_id))))
@@ -298,7 +297,6 @@ mod test_key_usage_from_attribute {
             values: sov,
         };
         let result = KeyUsages::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 
@@ -313,7 +311,6 @@ mod test_key_usage_from_attribute {
             values: sov,
         };
         let result = KeyUsages::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 
@@ -328,7 +325,6 @@ mod test_key_usage_from_attribute {
             values: sov,
         };
         let result = KeyUsages::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 }
@@ -353,7 +349,6 @@ mod test_basic_constraints_from_attribute {
         };
         let attribute = Attribute::try_from(bc).unwrap();
         let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_ok());
     }
 
@@ -368,7 +363,6 @@ mod test_basic_constraints_from_attribute {
             values: sov,
         };
         let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 
@@ -382,7 +376,6 @@ mod test_basic_constraints_from_attribute {
         let mut attribute = Attribute::try_from(bc).unwrap();
         attribute.oid = ObjectIdentifier::from_str("0.0.161.80085").unwrap();
         let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 
@@ -399,7 +392,6 @@ mod test_basic_constraints_from_attribute {
             values: sov,
         };
         let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
 
         let mut sov = SetOfVec::new();
@@ -412,7 +404,6 @@ mod test_basic_constraints_from_attribute {
             values: sov,
         };
         let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 
@@ -427,7 +418,6 @@ mod test_basic_constraints_from_attribute {
             values: sov,
         };
         let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
         assert!(result.is_err());
     }
 }

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -153,7 +153,7 @@ impl TryFrom<Capabilities> for Attributes {
             let insertion = sov.insert(Attribute::from(*item));
             if insertion.is_err() {
                 return Err(ConstraintError::Malformed(Some("Tried inserting non-unique element into SetOfVec. You likely have a duplicate value in your Capabilities".to_string())));
-            }*/
+            }
         }
         let insertion = sov.insert(Attribute::from(value.basic_constraints));
         if insertion.is_err() {

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -206,29 +206,6 @@ mod test {
     use spki::ObjectIdentifier;
 
     use super::*;
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn test_key_usage_to_object_identifier() {
-        // TODO
-        todo!()
-    }
-
-    fn test_key_usage_to_attribute(_val: bool) {
-        // TODO
-        todo!()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn test_key_usage_to_attribute_true() {
-        test_key_usage_to_attribute(true);
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn test_key_usage_to_attribute_false() {
-        test_key_usage_to_attribute(false);
-    }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -278,13 +255,6 @@ mod test_key_usage_from_attribute {
     use spki::ObjectIdentifier;
 
     use super::*;
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn test_key_usage_from_attribute() {
-        // TODO
-        todo!()
-    }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/certs/capabilities/mod.rs
+++ b/src/certs/capabilities/mod.rs
@@ -38,6 +38,8 @@ pub const OID_KEY_USAGE_ENCIPHER_ONLY: &str = "1.3.6.1.5.5.7.3.7";
 pub const OID_KEY_USAGE_DECIPHER_ONLY: &str = "1.3.6.1.5.5.7.3.6";
 /// Object Identifier for the BasicConstraints variant.
 pub const OID_BASIC_CONSTRAINTS: &str = "2.5.29.19";
+/// Object Identifier for the KeyUsage flag.
+pub const OID_KEY_USAGE: &str = "2.5.29.15";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Capabilities which an ID-Cert or ID-CSR might have. For ID-Certs, you'd find these capabilities
@@ -70,7 +72,7 @@ impl Capabilities {
     /// Sane default for actor [IdCsr]/[IdCert] [Capabilities]. Uses the DigitalSignature flag,
     /// not the ContentCommitment flag.
     pub fn default_actor() -> Self {
-        let key_usage = vec![KeyUsage::DigitalSignature(true)];
+        let key_usage = vec![KeyUsage::DigitalSignature];
         let basic_constraints = BasicConstraints {
             ca: false,
             path_length: None,
@@ -83,7 +85,7 @@ impl Capabilities {
 
     /// Sane default for home server [IdCsr]/[IdCert] [Capabilities].
     pub fn default_home_server() -> Self {
-        let key_usage = vec![KeyUsage::KeyCertSign(true)];
+        let key_usage = vec![KeyUsage::KeyCertSign];
         let basic_constraints = BasicConstraints {
             ca: true,
             path_length: Some(1),
@@ -151,7 +153,7 @@ impl TryFrom<Capabilities> for Attributes {
             let insertion = sov.insert(Attribute::from(*item));
             if insertion.is_err() {
                 return Err(ConstraintError::Malformed(Some("Tried inserting non-unique element into SetOfVec. You likely have a duplicate value in your Capabilities".to_string())));
-            }
+            }*/
         }
         let insertion = sov.insert(Attribute::from(value.basic_constraints));
         if insertion.is_err() {
@@ -399,23 +401,6 @@ mod test_basic_constraints_from_attribute {
         let result = BasicConstraints::try_from(attribute);
         dbg!(&result);
         assert!(result.is_ok());
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    fn test_basic_constraints_wrong_value_amount() {
-        let bc = BasicConstraints {
-            ca: true,
-            path_length: Some(0),
-        };
-        let mut attribute = Attribute::from(bc);
-        attribute
-            .values
-            .insert(Any::from(KeyUsage::DataEncipherment(false)))
-            .unwrap();
-        let result = BasicConstraints::try_from(attribute);
-        dbg!(&result);
-        assert!(result.is_err());
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/src/certs/idcerttbs.rs
+++ b/src/certs/idcerttbs.rs
@@ -193,9 +193,10 @@ impl<P: Profile, S: Signature, Q: PublicKey<S>> TryFrom<IdCertTbs<S, Q>>
             Ok(sernum) => sernum,
             Err(e) => {
                 return Err(ConversionError::InvalidInput(
-                    crate::errors::base::InvalidInput::Malformed(
-                        "Could not convert serial number".to_string(),
-                    ),
+                    crate::errors::base::InvalidInput::Malformed(format!(
+                        "Could not convert serial number: {}",
+                        e
+                    )),
                 ))
             }
         };

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -194,7 +194,6 @@ impl<S: Signature, P: PublicKey<S>> TryFrom<CertReq> for IdCsr<S, P> {
         Ok(IdCsr {
             inner_csr: IdCsrInner::try_from(value.info)?,
             signature_algorithm: value.algorithm,
-            // TODO: raw_bytes() or as_bytes()?
             signature: S::from_bitstring(value.signature.raw_bytes()),
         })
     }

--- a/src/certs/idcsr.rs
+++ b/src/certs/idcsr.rs
@@ -10,7 +10,7 @@ use x509_cert::attr::Attributes;
 use x509_cert::name::Name;
 use x509_cert::request::{CertReq, CertReqInfo};
 
-use crate::errors::composite::{IdCsrError, IdCsrInnerError};
+use crate::errors::composite::ConversionError;
 use crate::key::{PrivateKey, PublicKey};
 use crate::signature::Signature;
 use crate::{Constrained, ConstraintError};
@@ -62,7 +62,7 @@ impl<S: Signature, P: PublicKey<S>> IdCsr<S, P> {
         subject: &Name,
         signing_key: &impl PrivateKey<S, PublicKey = P>,
         capabilities: &Capabilities,
-    ) -> Result<IdCsr<S, P>, IdCsrError> {
+    ) -> Result<IdCsr<S, P>, ConversionError> {
         subject.validate()?;
         let inner_csr = IdCsrInner::<S, P>::new(subject, signing_key.pubkey(), capabilities)?;
         let signature = signing_key.sign(&inner_csr.clone().to_der()?);
@@ -118,12 +118,12 @@ impl<S: Signature, P: PublicKey<S>> IdCsr<S, P> {
     }
 
     /// Create an IdCsr from a byte slice containing a DER encoded PKCS #10 CSR.
-    pub fn from_der(bytes: &[u8]) -> Result<Self, IdCsrError> {
+    pub fn from_der(bytes: &[u8]) -> Result<Self, ConversionError> {
         IdCsr::try_from(CertReq::from_der(bytes)?)
     }
 
     /// Encode this type as DER, returning a byte vector.
-    pub fn to_der(self) -> Result<Vec<u8>, IdCsrError> {
+    pub fn to_der(self) -> Result<Vec<u8>, ConversionError> {
         Ok(CertReq::try_from(self)?.to_der()?)
     }
 }
@@ -160,7 +160,7 @@ impl<S: Signature, P: PublicKey<S>> IdCsrInner<S, P> {
         subject: &Name,
         public_key: &P,
         capabilities: &Capabilities,
-    ) -> Result<IdCsrInner<S, P>, IdCsrInnerError> {
+    ) -> Result<IdCsrInner<S, P>, ConversionError> {
         subject.validate()?;
         capabilities.validate()?;
 
@@ -177,18 +177,18 @@ impl<S: Signature, P: PublicKey<S>> IdCsrInner<S, P> {
     }
 
     /// Create an IdCsrInner from a byte slice containing a DER encoded PKCS #10 CSR.
-    pub fn from_der(bytes: &[u8]) -> Result<Self, IdCsrInnerError> {
+    pub fn from_der(bytes: &[u8]) -> Result<Self, ConversionError> {
         IdCsrInner::try_from(CertReqInfo::from_der(bytes)?)
     }
 
     /// Encode this type as DER, returning a byte vector.
-    pub fn to_der(self) -> Result<Vec<u8>, IdCsrInnerError> {
+    pub fn to_der(self) -> Result<Vec<u8>, ConversionError> {
         Ok(CertReqInfo::try_from(self)?.to_der()?)
     }
 }
 
 impl<S: Signature, P: PublicKey<S>> TryFrom<CertReq> for IdCsr<S, P> {
-    type Error = IdCsrError;
+    type Error = ConversionError;
 
     fn try_from(value: CertReq) -> Result<Self, Self::Error> {
         Ok(IdCsr {
@@ -201,7 +201,7 @@ impl<S: Signature, P: PublicKey<S>> TryFrom<CertReq> for IdCsr<S, P> {
 }
 
 impl<S: Signature, P: PublicKey<S>> TryFrom<CertReqInfo> for IdCsrInner<S, P> {
-    type Error = IdCsrInnerError;
+    type Error = ConversionError;
 
     fn try_from(value: CertReqInfo) -> Result<Self, Self::Error> {
         let rdn_sequence = value.subject;
@@ -222,7 +222,7 @@ impl<S: Signature, P: PublicKey<S>> TryFrom<CertReqInfo> for IdCsrInner<S, P> {
 }
 
 impl<S: Signature, P: PublicKey<S>> TryFrom<IdCsr<S, P>> for CertReq {
-    type Error = IdCsrError;
+    type Error = ConversionError;
 
     fn try_from(value: IdCsr<S, P>) -> Result<Self, Self::Error> {
         Ok(CertReq {
@@ -234,7 +234,7 @@ impl<S: Signature, P: PublicKey<S>> TryFrom<IdCsr<S, P>> for CertReq {
 }
 
 impl<S: Signature, P: PublicKey<S>> TryFrom<IdCsrInner<S, P>> for CertReqInfo {
-    type Error = IdCsrInnerError;
+    type Error = ConversionError;
     fn try_from(value: IdCsrInner<S, P>) -> Result<Self, Self::Error> {
         Ok(CertReqInfo {
             version: x509_cert::request::Version::V1,

--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -112,6 +112,8 @@ impl From<PublicKeyInfo> for SubjectPublicKeyInfoOwned {
     }
 }
 
+/// Checks, if the domain components of two [Name]s are equal and ordered in the same way. Returns
+/// `true`, if the domain components are equal, `false` otherwise.
 pub fn equal_domain_components(name_1: &Name, name_2: &Name) -> bool {
     let mut domain_components_1 = Vec::new();
     let mut domain_components_2 = Vec::new();

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -5,7 +5,7 @@
 use der::Length;
 use x509_cert::name::Name;
 
-use crate::certs::capabilities::{Capabilities, KeyUsage};
+use crate::certs::capabilities::{Capabilities, KeyUsage, KeyUsages};
 use crate::certs::idcert::IdCert;
 use crate::certs::idcerttbs::IdCertTbs;
 use crate::certs::idcsr::IdCsr;

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -144,22 +144,22 @@ impl Constrained for Capabilities {
 
         // Iterate over all the entries in the KeyUsage vector, check if they exist/are true
         for item in self.key_usage.iter() {
-            if !has_only_encipher && item == &KeyUsage::EncipherOnly(true) {
+            if !has_only_encipher && item == &KeyUsage::EncipherOnly {
                 has_only_encipher = true;
             }
-            if !has_only_decipher && item == &KeyUsage::DecipherOnly(true) {
+            if !has_only_decipher && item == &KeyUsage::DecipherOnly {
                 has_only_decipher = true;
             }
-            if !has_key_agreement && item == &KeyUsage::KeyAgreement(true) {
+            if !has_key_agreement && item == &KeyUsage::KeyAgreement {
                 has_key_agreement = true;
             }
-            if !has_key_agreement && item == &KeyUsage::ContentCommitment(true) {
+            if !has_key_agreement && item == &KeyUsage::ContentCommitment {
                 can_commit_content = true;
             }
-            if !has_key_agreement && item == &KeyUsage::DigitalSignature(true) {
+            if !has_key_agreement && item == &KeyUsage::DigitalSignature {
                 can_sign = true;
             }
-            if !has_key_agreement && item == &KeyUsage::KeyCertSign(true) {
+            if !has_key_agreement && item == &KeyUsage::KeyCertSign {
                 key_cert_sign = true;
             }
         }

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -5,7 +5,7 @@
 use der::Length;
 use x509_cert::name::Name;
 
-use crate::certs::capabilities::{Capabilities, KeyUsage, KeyUsages};
+use crate::certs::capabilities::{Capabilities, KeyUsage};
 use crate::certs::idcert::IdCert;
 use crate::certs::idcerttbs::IdCertTbs;
 use crate::certs::idcsr::IdCsr;

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -143,7 +143,7 @@ impl Constrained for Capabilities {
         let mut has_key_agreement = false;
 
         // Iterate over all the entries in the KeyUsage vector, check if they exist/are true
-        for item in self.key_usage.iter() {
+        for item in self.key_usage.key_usages.iter() {
             if !has_only_encipher && item == &KeyUsage::EncipherOnly {
                 has_only_encipher = true;
             }

--- a/src/errors/base.rs
+++ b/src/errors/base.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use spki::ObjectIdentifier;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Clone)]
@@ -21,29 +20,12 @@ pub enum ConstraintError {
 /// Represents errors for invalid input in IdCsr or IdCert generation.
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum InvalidInput {
-    #[error("The der library has reported the following error with the input")]
-    DerError(der::Error),
-    #[error("subject_session_id MUST NOT exceed length limit of 32 characters")]
-    SessionIdTooLong,
-    #[error(
-        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
-    )]
-    IncompatibleVariantForConversion { reason: String },
-    #[error("Critical extension cannot be converted")]
-    UnknownCriticalExtension { oid: ObjectIdentifier },
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-    #[error(transparent)]
-    UnsuccessfulConversion(#[from] UnsuccessfulConversion),
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-// TODO: Replace usages of InvalidInput::IncompatibleVariantForConversion with this Enum
-pub enum UnsuccessfulConversion {
-    #[error(
-        "Cannot perform conversion, as input variant can not be converted to output. {reason:}"
-    )]
-    IncompatibleVariant { reason: String },
-    #[error("Conversion failed due to invalid input")]
-    InvalidInput(String),
+    #[error("The value is malformed and cannot be used as input: {0}")]
+    Malformed(String),
+    #[error("The value was expected to be between {min_length:?} and {max_length:?} but was {actual_length:?}")]
+    Length {
+        min_length: usize,
+        max_length: usize,
+        actual_length: String,
+    },
 }

--- a/src/errors/base.rs
+++ b/src/errors/base.rs
@@ -33,6 +33,8 @@ pub enum InvalidInput {
     UnknownCriticalExtension { oid: ObjectIdentifier },
     #[error(transparent)]
     ConstraintError(#[from] ConstraintError),
+    #[error(transparent)]
+    UnsuccessfulConversion(#[from] UnsuccessfulConversion),
 }
 
 #[derive(Error, Debug, PartialEq, Clone)]

--- a/src/errors/composite.rs
+++ b/src/errors/composite.rs
@@ -7,40 +7,6 @@ use thiserror::Error;
 
 use super::base::{ConstraintError, InvalidInput};
 
-/// Error type covering possible failures when converting a [x509_cert::TbsCertificate]
-/// to a [crate::cert::IdCertTbs]
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum TbsCertToIdCert {
-    #[error("field 'subject_unique_id' was None. Expected: Some(der::asn1::BitString)")]
-    SubjectUid,
-    #[error("field 'extensions' was None. Expected: Some(x509_cert::ext::Extensions)")]
-    Extensions,
-    #[error("Supplied integer too long")]
-    Signature(der::Error),
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-    #[error(transparent)]
-    InvalidInput(#[from] InvalidInput),
-    #[error("Encounter DER encoding error")]
-    DerError(der::Error),
-}
-
-impl From<der::Error> for TbsCertToIdCert {
-    fn from(value: der::Error) -> Self {
-        Self::DerError(value)
-    }
-}
-
-/// Error type covering possible failures when converting a [crate::cert::IdCertTbs]
-/// to a [x509_cert::TbsCertificate]
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum IdCertToTbsCert {
-    #[error("Serial number could not be converted")]
-    SerialNumber(der::Error),
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-}
-
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum InvalidCert {
     #[error("The signature does not match the contents of the certificate")]
@@ -55,110 +21,12 @@ pub enum InvalidCert {
     InvalidCapabilities(ConstraintError),
 }
 
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum CertReqToIdCsr {
-    #[error(transparent)]
-    CertReqInfoToIdCsrInner(#[from] CertReqInfoError),
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum CertReqInfoError {
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-    #[error(transparent)]
-    InvalidInput(#[from] InvalidInput),
-    #[error("Couldn't parse CertReqInfo from provided DER bytes")]
-    DerError(der::Error),
-    #[error(transparent)]
-    MalformedIdCsrInner(#[from] IdCsrInnerError),
-}
-
-impl From<der::Error> for CertReqInfoError {
-    fn from(value: der::Error) -> Self {
-        Self::DerError(value)
-    }
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum IdCsrError {
-    #[error("The Bitstring is invalid")]
-    InvalidBitstring(der::Error),
-    #[error(transparent)]
-    IdCsrInnerToCertReqInfo(#[from] IdCsrInnerError),
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-}
-
-impl From<der::Error> for IdCsrError {
-    fn from(value: der::Error) -> Self {
-        Self::InvalidBitstring(value)
-    }
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum IdCsrInnerError {
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-    #[error("Encountered DER encoding error")]
-    DerError(der::Error),
-    #[error(transparent)]
-    InvalidInput(#[from] InvalidInput),
-}
-
-impl From<der::Error> for IdCsrInnerError {
-    fn from(value: der::Error) -> Self {
-        Self::DerError(value)
-    }
-}
-
 #[derive(Error, Debug, PartialEq, Hash, Clone)]
 pub enum PublicKeyError {
     #[error("The signature does not match the data")]
     BadSignature,
     #[error("The provided PublicKeyInfo could not be made into a PublicKey")]
     BadPublicKeyInfo,
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum IdCertTbsError {
-    #[error(transparent)]
-    PublicKeyError(#[from] PublicKeyError),
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-    #[error(transparent)]
-    IdCsrInnerError(#[from] IdCsrInnerError),
-    #[error(transparent)]
-    IdCertToTbsCert(#[from] IdCertToTbsCert),
-    #[error("Encountered DER encoding error")]
-    DerError(der::Error),
-}
-
-impl From<der::Error> for IdCertTbsError {
-    fn from(value: der::Error) -> Self {
-        Self::DerError(value)
-    }
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-pub enum IdCertError {
-    #[error(transparent)]
-    PublicKeyError(#[from] PublicKeyError),
-    #[error("Encountered DER encoding error")]
-    DerError(der::Error),
-    #[error(transparent)]
-    IdCertTbsError(#[from] IdCertTbsError),
-    #[error(transparent)]
-    IdCertToTbsCert(#[from] IdCertToTbsCert),
-    #[error(transparent)]
-    TbsCertToIdCert(#[from] TbsCertToIdCert),
-    #[error(transparent)]
-    ConstraintError(#[from] ConstraintError),
-}
-
-impl From<der::Error> for IdCertError {
-    fn from(value: der::Error) -> Self {
-        Self::DerError(value)
-    }
 }
 
 #[derive(Error, Debug, PartialEq, Clone)]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -7,7 +7,6 @@ pub mod base;
 /// "Composite" error types which consist of one or more "base" error types
 pub mod composite;
 
-// TODO
 // PRETTYFYME
 // This module can be restructured to be a reflection of the src/ file tree. It would then be very
 // easy to tell, which file covers error types of which data types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,9 @@ pub mod errors;
 
 pub(crate) mod constraints;
 
+pub use der;
+pub use spki;
+
 /// Traits implementing [Constrained] can be validated to be well-formed. This does not guarantee
 /// that a validated type will always be *correct* in the context it is in.
 ///


### PR DESCRIPTION
I misread and/or misinterpreted information from RFC5280, describing the KeyUsage extension. This PR properly implements the KeyUsage extension as intended in RFC5280 (closes #28), closes #29, re-exports `der` and `spki` and makes errors a little nicer.

The PR also adds a new example called `ed25519_from_der`, which shows how to create a certificate by importing DER encoded bytes.